### PR TITLE
Added in logic to hide the loading view and show the checkin survey a…

### DIFF
--- a/css/scss/apps/thirdchannel/_surveys.scss
+++ b/css/scss/apps/thirdchannel/_surveys.scss
@@ -67,6 +67,14 @@
     margin-bottom: 2em;
   }
 
+  .checkin-form, .loading-section {
+    display: none;
+
+    &.open {
+      display: block;
+    }
+  }
+
   .expanding-wrapper {
     width: 100%;
   }

--- a/js/apps/thirdchannel/views/checkins/show/checkin.js
+++ b/js/apps/thirdchannel/views/checkins/show/checkin.js
@@ -55,6 +55,9 @@ define(function(require) {
                 unhighlight: this.unhighlight
             });
 
+            this.$(".checkin-form").addClass('open');
+            this.$(".loading-section").removeClass('open');
+
             return this;
         },
         saveState: function(e) {


### PR DESCRIPTION
This is for ticket TC-1833.  The original problem was that images were not being attached to checkins.  The actual issue is that on a slow connection, the javascript isn't loaded until a while after the page shows content.  This allowed users to perform actions on our page without any javascript running.  That allowed users to do things like submit checkins without images.  The solution is to show a loading screen until the page/javascript has been loaded.  This is part 2 or 2 repos that contain this fix (other being foliage).

This repo contains the logic to show the survey form and hide the loading view for the checkin survey page.