### PR TITLE
Optional images

### DIFF
--- a/css/scss/layout/_base_layout.scss
+++ b/css/scss/layout/_base_layout.scss
@@ -248,6 +248,7 @@
   border: 1px solid $border-color;
   border-radius: $border-radius-base;
   margin-bottom: 2em;
+  position: relative;
 }
 
 .footer {

--- a/css/scss/modules/_data_section.scss
+++ b/css/scss/modules/_data_section.scss
@@ -12,7 +12,7 @@
 	
 	.expand-indicator {
 		position: absolute;
-		right: 8%;
+		right: 2rem;
 		padding-right: 0;
 	}
 

--- a/js/apps/singleNickel/models/question.js
+++ b/js/apps/singleNickel/models/question.js
@@ -30,6 +30,11 @@ define(function(require){
                     text: "Fill in some text",
                     hideSiblings: "#questionMultiple,#questionExplain,#questionPlaceholder"
                 },
+                "QuestionSummary": {
+                    text: "Describing their overall visit",
+                    hideSiblings: "#questionMultiple,#questionExplain",
+                    showSiblings: "#questionPlaceholder"
+                },
                 "QuestionDatetime": {
                     text: "Select a date and time",
                     hideSiblings: "#questionMultiple,#questionExplain,#questionPlaceholder"

--- a/js/apps/singleNickel/templates/hbs-compiled.js
+++ b/js/apps/singleNickel/templates/hbs-compiled.js
@@ -765,6 +765,18 @@ function program9(depth0,data) {
   return buffer;
   }));
 
+Handlebars.registerPartial("QuestionSummary", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+  var buffer = "", stack1, functionType="function", escapeExpression=this.escapeExpression;
+
+
+  buffer += "<input type=\"text\" placeholder=\""
+    + escapeExpression(((stack1 = ((stack1 = (depth0 && depth0.attributes)),stack1 == null || stack1 === false ? stack1 : stack1.placeholder)),typeof stack1 === functionType ? stack1.apply(depth0) : stack1))
+    + "\">";
+  return buffer;
+  }));
+
 Handlebars.registerPartial("QuestionText", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};

--- a/js/apps/thirdchannel/views/checkins/show/checkin.js
+++ b/js/apps/thirdchannel/views/checkins/show/checkin.js
@@ -109,8 +109,8 @@ define(function(require) {
             var questionsValid = this.$form.valid(),
                 imagesValid = true;
 
-            var $beforeImages = this.$('.images.before'),
-                $afterImages = this.$('.images.after');
+            var $beforeImages = this.$('.images.before[required]'),
+                $afterImages = this.$('.images.after[required]');
 
             if ($beforeImages.length > 0 || $afterImages.length > 0) {
                 // TODO: move to template?

--- a/js/apps/thirdchannel/views/checkins/show/checkin.js
+++ b/js/apps/thirdchannel/views/checkins/show/checkin.js
@@ -112,43 +112,45 @@ define(function(require) {
             var $beforeImages = this.$('.images.before'),
                 $afterImages = this.$('.images.after');
 
-            // TODO: move to template?
-            var requiredLabel = '<label class="error">This field is required.</label>';
+            if ($beforeImages.length > 0 || $afterImages.length > 0) {
+                // TODO: move to template?
+                var requiredLabel = '<label class="error">This field is required.</label>';
 
-            // TODO: jquery validator doesn't play nice with input arrays... This should get updated once we re-arch the checkin system
-            // clean up existing errors before re-validating
-            $beforeImages.removeClass('error');
-            $beforeImages.find('label.error').remove();
+                // TODO: jquery validator doesn't play nice with input arrays... This should get updated once we re-arch the checkin system
+                // clean up existing errors before re-validating
+                $beforeImages.removeClass('error');
+                $beforeImages.find('label.error').remove();
 
-            $afterImages.removeClass('error');
-            $afterImages.find('label.error').remove();
+                $afterImages.removeClass('error');
+                $afterImages.find('label.error').remove();
 
-            this.$('.image_label').parent().removeClass('error');
+                this.$('.image_label').parent().removeClass('error');
 
-            if($beforeImages.find('.holder').length === 0) {
-                $beforeImages.addClass('error');
-                this.$('#before_file').after(requiredLabel);
-                imagesValid = false;
-            }
-
-            if($afterImages.find('.holder').length === 0) {
-                $afterImages.addClass('error');
-                this.$('#after_file').after(requiredLabel);
-                imagesValid = false;
-            }
-
-            // verify labels are present for all images
-            var $labels = this.$('.body.images .image_label');
-
-            _.each($labels, function(labelField) {
-                var $labelField = $(labelField);
-                if($labelField.val() === '') {
+                if($beforeImages.find('.holder').length === 0) {
+                    $beforeImages.addClass('error');
+                    this.$('#before_file').after(requiredLabel);
                     imagesValid = false;
-
-                    $labelField.parent().addClass('error');
-                    $labelField.parent().append(requiredLabel);
                 }
-            });
+
+                if($afterImages.find('.holder').length === 0) {
+                    $afterImages.addClass('error');
+                    this.$('#after_file').after(requiredLabel);
+                    imagesValid = false;
+                }
+
+                // verify labels are present for all images
+                var $labels = this.$('.body.images .image_label');
+
+                _.each($labels, function(labelField) {
+                    var $labelField = $(labelField);
+                    if($labelField.val() === '') {
+                        imagesValid = false;
+
+                        $labelField.parent().addClass('error');
+                        $labelField.parent().append(requiredLabel);
+                    }
+                });
+            }
 
             return questionsValid && imagesValid;
         },

--- a/templates/handlebars/singleNickel/survey/show/partials/_QuestionSummary.hbs
+++ b/templates/handlebars/singleNickel/survey/show/partials/_QuestionSummary.hbs
@@ -1,0 +1,1 @@
+<input type="text" placeholder="{{attributes.placeholder}}">


### PR DESCRIPTION
This contains source code for about 3 tasks.
- First is the summary question on the survey builder.  Since this question type will be coming sometime soon, I don't think we need to worry about extracting it out, since we don't have any surveys we're building in the near future.
- Second is the fixes for a collapse and expand buttons on the reports.  Quick fix.
- Third is the optional images.  I've expanded the valid method to look for the existence of a required before and after image.  If they exist than they are checked for the usual things, otherwise we allow the user to enter an image if they want in either the before or after areas.