### PR TITLE
tc-2648: load widgets in order

### DIFF
--- a/js/apps/thirdchannel/views/reports/async_report.js
+++ b/js/apps/thirdchannel/views/reports/async_report.js
@@ -108,38 +108,13 @@ define(function(require) {
             },
 
             _renderWidget: function(meta_data, widget_data) {
-                // look at each rendered widget. if zero, render right away. other wise, step through each widget
-                // if target.idx < current.idx, proceed
-                // if target.idx > current.idx, preppend to target
-
                 if (meta_data.report_widget_uuid !== widget_data.uuid) {
                     console.error("Meta data report_widget uuid and the response uuid are not equal!");
                 }
-                // I am not a fan of this.
-                var $widget = new WidgetView(widget_data).render().$el,
-                    $widgetsContainer = this.$el.find("[data-id='" + meta_data.report_subsection_uuid +"'] .widgets"),
-                    $widgets = $widgetsContainer.find('.widget'),
-                    max = $widgets.length,
-                    rendered = false,
-                    i = 0,
-                    existingIdx = 0;
-                // set the index on the main widget
-                $widget.attr('data-idx', meta_data.idx);
-
-                for (i = 0; i < max; i++) {
-                    existingIdx = parseInt($($widgets[i]).attr('data-idx'), 10);
-                    if (existingIdx && existingIdx > meta_data.idx) {
-                        $widget.insertBefore($($widgets[i]));
-                        rendered = true;
-                        break;
-                    }
-                }
-                if (!rendered) {
-                    $widget.hide();
-                    $widgetsContainer.append($widget);
-                    $widget.fadeIn(500);
-                }
-                
+                var $widget = new WidgetView(widget_data).render().$el;
+                $widget.hide();
+                $("#widget-placeholder-"+widget_data.uuid).replaceWith($widget);
+                $widget.fadeIn(500);
                 //trigger the drawing of the d3 widgets
                 context.trigger("report post render");
             },
@@ -151,8 +126,13 @@ define(function(require) {
                 _.each(section.subsections, function(subsection) {
                     subsection.title = subsection.name;
                     var $subsectionsContainer = $section.find('.subsections');
-                    $subsectionsContainer.append(Templates['thirdchannel/reports/index/subsection'](subsection));
-                    //$subsectionsContainer.append("<i class='fa fa-spin fa-spinner fa-2x widget-spinner'></i>");
+                    var $subsection = $(Templates['thirdchannel/reports/index/subsection'](subsection));
+                    _.chain(subsection.widgets).sortBy('idx').each(function(widget) {
+                      $('<div/>', {
+                          id: 'widget-placeholder-' + widget.report_widget_uuid,
+                      }).hide().appendTo($subsection);
+                    });
+                    $subsectionsContainer.append($subsection);
                 });
                 this.$el.append($section);
             }


### PR DESCRIPTION
https://thirdchannel.atlassian.net/browse/TC-2648

The code that inserted widgets in their idx-dependent order was not always working right. I changed the way the async_report view works in order to make it consistent. Now, when the report_meta is render as the report skeleton, hidden placeholders are created for each widget. When each widget is rendered, the placeholder is swapped out for the actual widget view.