### PR TITLE
tc-2706: load up a new report_meta when the filter changes

### DIFF
--- a/js/apps/thirdchannel/views/reports/index/report.js
+++ b/js/apps/thirdchannel/views/reports/index/report.js
@@ -11,9 +11,9 @@ define(function(require) {
             this._attachAsyncLoader();
             this.listenTo(this.reportLoader, "reports:async:complete", function() {
                 this.$el.find(".loading-section").slideUp(500);
-                this.listenToOnce(context, "filter:query", this.render);
+                this.listenToOnce(context, "filter:query", this.rerender);
             }.bind(this));
-            this.listenTo(this.reportLoader, "reports:async:incomplete", this.render);
+            this.listenTo(this.reportLoader, "reports:async:incomplete", this.rerender);
         },
         _attachAsyncLoader: function() {
             this.reportLoader = new AsyncReportLoader(context.current_report);
@@ -24,6 +24,18 @@ define(function(require) {
           this.$el.append(this.loadingView.render().$el);
           this.reportLoader.layout();
           this.reportLoader.loadWidgets(window.location.search.substring(1));
+          return this;
+        },
+        rerender: function(qs){
+          this.$el.empty();
+          this.$el.append(this.loadingView.render().$el);
+          var report_id_match = /report=(\d+)/.exec(qs);
+          if(report_id_match !== null){
+            $.getJSON(context.links.reports.meta + "?report=" + report_id_match[1], function(data){
+              this.reportLoader.layout(data);
+              this.reportLoader.loadWidgets(qs);
+            }.bind(this));
+          }
           return this;
         }
     });


### PR DESCRIPTION
https://thirdchannel.atlassian.net/browse/TC-2706

see also: https://github.com/RSV2/ThirdChannel/pull/192

When the filter was changing, the report was staying the same. Now when the filter changes, we should get a new report_meta before starting the async widget loading process.