### PR TITLE
tc-2774: if report param is not present, just get the default report

### DIFF
--- a/js/apps/thirdchannel/views/reports/index/report.js
+++ b/js/apps/thirdchannel/views/reports/index/report.js
@@ -33,16 +33,19 @@ define(function(require) {
           this.reportLoader.loadWidgets(window.location.search.substring(1));
           return this;
         },
-        rerender: function(qs){
+        rerender: function(){
+          var qs = window.location.search.substring(1);
           this.$el.empty();
           this.$el.append(this.loadingView.render().$el);
           var report_id_match = /report=(\d+)/.exec(qs);
+          var uri = context.links.reports.meta;
           if(report_id_match !== null){
-            $.getJSON(context.links.reports.meta + "?report=" + report_id_match[1], function(data){
+              uri += "?report=" + report_id_match[1];
+          }
+          $.getJSON(uri, function(data){
               this.reportLoader.layout(data);
               this.reportLoader.loadWidgets(qs);
-            }.bind(this));
-          }
+          }.bind(this));
           return this;
         }
     });


### PR DESCRIPTION
https://thirdchannel.atlassian.net/browse/TC-2774

I forgot to include the case where the "report" param was left blank when loading a different report