### PR TITLE
Allow user to clone surveys to different customers

### DIFF
--- a/js/apps/singleNickel/models/survey.js
+++ b/js/apps/singleNickel/models/survey.js
@@ -60,9 +60,9 @@ define(function(require){
 
             return (this.sync || Backbone.sync).call(this, null, this, options);
         },
-        cloneSurvey: function(opts) {
+        cloneSurvey: function(opts, customer) {
             var options = {
-                url: this.url() + '/clone',
+                url: this.url() + '/clone' + (customer ? '?customer_uuid=' + customer : ''),
                 type: 'POST'
             };
 

--- a/js/apps/singleNickel/views/survey/list_item.js
+++ b/js/apps/singleNickel/views/survey/list_item.js
@@ -10,7 +10,8 @@ define(function(require) {
           'click .delete': 'removeSurvey',
           'click .lock': 'toggleLock',
           'click .reindex': 'reindexSurvey',
-          'click .clone': 'cloneSurvey'
+          'click .clone': 'toggleClone',
+            'click .save-clone': 'cloneSurvey'
         },
         initialize: function() {
             _.bindAll(this, 'removeSurvey', 'toggleLock');
@@ -18,8 +19,10 @@ define(function(require) {
         },
         render: function() {
             var attributes = _.extend({survey: this.model}, this.model.toJSON());
-            this.$el.html(this.template(attributes));
+            var customers = _.extend(attributes, {customers : context.customers.models});
+            this.$el.html(this.template(customers));
             this.$el.attr("data-survey", this.model.get("id"));
+            this.$el.find("#clone-customer-container").hide();
             return this;
         },
         removeSurvey: function(e) {
@@ -43,6 +46,20 @@ define(function(require) {
                 context.trigger('error');
             });
         },
+        toggleClone: function(e) {
+            e.preventDefault();
+            var self = this;
+            var container = $("#clone-customer-container");
+
+            if (container[0].className === 'visible') {
+                container.hide('fast', "linear");
+                container.removeClass('visible');
+            }
+            else {
+                container.addClass('visible');
+                container.show('fast', "linear");
+            }
+        },
         reindexSurvey: function(e) {
             e.preventDefault();
 
@@ -56,9 +73,12 @@ define(function(require) {
             e.preventDefault();
 
             var self = this;
-
-            this.model.cloneSurvey().done(function(response) {
-                self.model.collection.add(response);
+            var customerUUID = $("#clone-customer-select")[0].value;
+            this.model.cloneSurvey(null, customerUUID).done(function(response) {
+                if(response.customer_uuid === self.model.get('customer_uuid')) {
+                    self.model.collection.add(response);
+                }
+                alert("Succesfully cloned survey to " + response.customer + '!');
             }).fail(function() {
                 context.trigger('error');
             });

--- a/templates/handlebars/singleNickel/survey/list_item.hbs
+++ b/templates/handlebars/singleNickel/survey/list_item.hbs
@@ -10,10 +10,22 @@
             <a href="/{{customer_uuid}}/surveys" class="btn light round reindex" alt="Re-Index"><i class="ic fa ic_check"></i></a>
         {{/isAdmin}}
     {{/if}}
-    <a href="/{{customer_uuid}}/surveys" class="btn light round clone" alt="Clone Survey"><i class="ic fa ic_sheep"></i></a>
-    <a data-bypass="true" class="btn light round" href="{{links.export}}" alt="Export Survey YAML"><i class="ic fa ic_download"></i></a>
     {{#isSuperAdmin}}
         <a class="btn light round lock" href="/{{customer_uuid}}/surveys" alt="Toggle Locked"><i class="ic fa {{ lockActionIconClass locked }}"></i></a>
     {{/isSuperAdmin}}
+    <a data-bypass="true" class="btn light round" href="{{links.export}}" alt="Export Survey YAML"><i class="ic fa ic_download"></i></a>
+    <a href="/{{customer_uuid}}/surveys" class="btn light round clone" alt="Clone Survey"><i class="ic fa ic_sheep"></i></a>
+    <div id="clone-customer-container">
+        <label>Clone Customer:</label>
+        <select style="width: 50%;" id="clone-customer-select" name="clone_customer">
+            <option value="{{customer_uuid}}">{{customer}}</option>
+            {{#select customer}}
+                {{#each customers}}
+                    <option value="{{attributes.uuid}}">{{attributes.name}}</option>
+                {{/each}}
+            {{/select}}
+        </select>
+        <button id="clone-save" class="btn light solid save-clone">Clone Survey</button>
+    </div>
 </td>
 <td class="idx-handle"><i class="ic ic_hamburger medium-blue"></i></td>


### PR DESCRIPTION
Linked PR: SingleNickel TC-3005
UI update to allow users to clone surveys to different customers 
- added dropdown to allow users to pick the customer that the survey should clone to when attempting to clone a survey (defaults to current customer).