### PR TITLE
TC-4254: remove function that was adding the discontinued customer_store_id param

### DIFF
--- a/js/apps/thirdchannel/views/labs/sales_comparison/side.js
+++ b/js/apps/thirdchannel/views/labs/sales_comparison/side.js
@@ -23,7 +23,7 @@ define(function(require) {
                 if (options.groupSelect === undefined) {
                     throw "No 'groupSelect' parameter set in constructor for the SalesCompareSideView";
                 }
-                _.bindAll(this, 'applyFilter', 'reportComplete', 'updateLinks');
+                _.bindAll(this, 'applyFilter', 'reportComplete');
                 this.$groupSelect = options.groupSelect;
                 this.model = new SalesCompareModel();
                 this.reportLoader = new AsyncReportLoader(context.current_report);
@@ -50,17 +50,6 @@ define(function(require) {
                 this.model.fetch();
             },
 
-            updateLinks: function (e) {
-                e.preventDefault();
-                e.stopPropagation();
-                var $link = $(e.currentTarget),
-                    href = $link.attr("href");
-                if (this.global !== true) {
-                    href = href + "&customer_store_id=" + this.model.get('report').customer_store_id;
-                }
-                window.location = "../" + href;
-            },
-
             render: function () {
                 this.$el.empty().append(this.loadingTemplate()).append(this.saleSectionTemplate());
 
@@ -73,7 +62,6 @@ define(function(require) {
 
             reportComplete: function() {
                 this.$(".loading-section").remove();
-                this.$(".breakdown-link").on("click", this.updateLinks);
             },
 
             _renderSales: function () {


### PR DESCRIPTION
https://thirdchannel.atlassian.net/browse/TC-4254

This removes a function that was adding an `onClick` action to the "View Breakdown" links in order to add a `customer_store_id` param. This was rewriting the `href`s incorrectly, which is why the links broke when opening the links normally. Opening them in a new tab worked fine because it did not trigger the `onClick`. @spember added the function originally, but was not sure what the `customer_store_id` param was used for. It does not seem to be used now, and it doesn't seem like it was ever used in `Reports::InfoController`. In all the cases I tried, it was being set to `null` anyway. The breakdowns appear to work fine without it.