### PR TITLE
PS-435 Show loading indicator when waiting for filtered results

### DIFF
--- a/js/apps/thirdchannel/views/activities/activities.js
+++ b/js/apps/thirdchannel/views/activities/activities.js
@@ -8,13 +8,11 @@ define(function (require) {
         Expanding = require('expanding'),
         Livestamp = require('livestamp'),
         InfiniteScrollView = require('thirdchannel/views/shared/infinite_scroll'),
-        LoadingView = require('thirdchannel/views/activities/loading'),
-        HandlebarsTemplates = require('handlebarsTemplates');
+        LoadingView = require('thirdchannel/views/activities/loading');
 
     var ActivitiesView = InfiniteScrollView.extend({
         el: '.activities-holder',
         infiniteCollectionClass: ActivityCollection,
-        loadingTemplate: HandlebarsTemplates['thirdchannel/loading'],
 
         endOfFeedHTML: "<div class='activity alert info'>You have reached the end of the feed!</div>",
         errorHTML: '<div class="activity alert error">Additional activities cannot be loaded due to an error on the server. Please contact Tech Support</div>',
@@ -86,7 +84,6 @@ define(function (require) {
 
         insertLoadingTemplate: function () {
           this.loadIndicator = new LoadingView();
-          this.loadIndicator.template = this.loadingTemplate;
           this.$el.prepend(this.loadIndicator.render().el);
         },
 

--- a/js/apps/thirdchannel/views/activities/activities.js
+++ b/js/apps/thirdchannel/views/activities/activities.js
@@ -7,11 +7,14 @@ define(function (require) {
         IncompleteActivity = require('thirdchannel/models/activities/incomplete_activity'),
         Expanding = require('expanding'),
         Livestamp = require('livestamp'),
-        InfiniteScrollView = require('thirdchannel/views/shared/infinite_scroll');
+        InfiniteScrollView = require('thirdchannel/views/shared/infinite_scroll'),
+        LoadingView = require('thirdchannel/views/activities/loading'),
+        HandlebarsTemplates = require('handlebarsTemplates');
 
     var ActivitiesView = InfiniteScrollView.extend({
         el: '.activities-holder',
         infiniteCollectionClass: ActivityCollection,
+        loadingTemplate: HandlebarsTemplates['thirdchannel/loading'],
 
         endOfFeedHTML: "<div class='activity alert info'>You have reached the end of the feed!</div>",
         errorHTML: '<div class="activity alert error">Additional activities cannot be loaded due to an error on the server. Please contact Tech Support</div>',
@@ -22,13 +25,14 @@ define(function (require) {
 
             this.incompleteActivityUrl = options.incompleteActivityUrl;
 
+            this.listenTo(context, 'filter:query', this.insertLoadingTemplate);
             this.listenToOnce(context, 'page:height', this.checkPageHeight);
             $(window).resize(function () {
                 self.resizeCarousel();
             });
             ActivitiesView.__super__.initialize.apply(this, arguments);
         },
-        
+
 
         fetch: function () {
             var self = this;
@@ -46,7 +50,7 @@ define(function (require) {
 
             return this;
         },
-        
+
 
         renderModel: function (model) {
             for (var i = 0; i<model.attributes.length; i++) {
@@ -71,7 +75,7 @@ define(function (require) {
                 this.getContentElement().append(this.endOfFeedHTML);
             }
         },
-        
+
         resizeCarousel: function () {
             var $carousel = self.$('.carousel');
             var width = $carousel.width();
@@ -79,6 +83,13 @@ define(function (require) {
             self.$('.slick-slide').height(width);
             $carousel.find('img').css({'max-width': width, 'max-height': width});
         },
+
+        insertLoadingTemplate: function () {
+          this.loadIndicator = new LoadingView();
+          this.loadIndicator.template = this.loadingTemplate;
+          this.$el.prepend(this.loadIndicator.render().el);
+        },
+
         getContentElement: function () {
             return this.$('.complete');
         }

--- a/js/apps/thirdchannel/views/activities/activities.js
+++ b/js/apps/thirdchannel/views/activities/activities.js
@@ -7,8 +7,7 @@ define(function (require) {
         IncompleteActivity = require('thirdchannel/models/activities/incomplete_activity'),
         Expanding = require('expanding'),
         Livestamp = require('livestamp'),
-        InfiniteScrollView = require('thirdchannel/views/shared/infinite_scroll'),
-        LoadingView = require('thirdchannel/views/activities/loading');
+        InfiniteScrollView = require('thirdchannel/views/shared/infinite_scroll');
 
     var ActivitiesView = InfiniteScrollView.extend({
         el: '.activities-holder',
@@ -83,7 +82,6 @@ define(function (require) {
         },
 
         insertLoadingTemplate: function () {
-          this.loadIndicator = new LoadingView();
           this.$el.prepend(this.loadIndicator.render().el);
         },
 


### PR DESCRIPTION
**What:** Pulled in LoadingView into the activity feed, so that we can display it when we are waiting for filters to be applied on the feed.

**Why:** To provide better visual indicator that the system is still thinking or has finished.

**JIRA:** https://thirdchannel.atlassian.net/browse/PS-435

<img width="1440" alt="ps-435" src="https://cloud.githubusercontent.com/assets/579649/21197110/3a9d870c-c208-11e6-8480-4784474747a9.png">
