### PR TITLE
Remove seconds from formatSecondsToDate helper

### DIFF
--- a/js/apps/shared/utils/handlebarsHelpers.js
+++ b/js/apps/shared/utils/handlebarsHelpers.js
@@ -219,7 +219,6 @@ define(function (require) {
             timeString = date.toLocaleTimeString(locale, {
                 hour: "2-digit",
                 minute: "2-digit",
-                second: "2-digit",
                 timeZoneName: "short"
             });
 
@@ -288,4 +287,3 @@ define(function (require) {
         return Math.round(value);
     });
 });
-


### PR DESCRIPTION
**What:** Remove the seconds display from Activity Feed posts, Store profile > Activity Feed posts, and Agenct profile > Activity feed posts. This helper is only used by these areas, so it doesn't indirectly affect other areas.

**Why:** Nobody needs that.

**JIRA:** https://thirdchannel.atlassian.net/browse/TC-4811