### PR TITLE
Trim excess new lines from activity summaries.

### DIFF
--- a/css/scss/apps/thirdchannel/_activities.scss
+++ b/css/scss/apps/thirdchannel/_activities.scss
@@ -82,7 +82,6 @@ $padding: 1.5em;
 .activity {
   p {
     margin: 0 0 0 0;
-    white-space: pre-wrap;
   }
   background: white;
   border-radius: $border-radius-base;
@@ -331,6 +330,10 @@ $padding: 1.5em;
 
 .activity-content img {
   max-width: 100%;
+}
+
+.activity-content p {
+  white-space: pre-wrap;
 }
 
 .action {

--- a/css/scss/apps/thirdchannel/_activities.scss
+++ b/css/scss/apps/thirdchannel/_activities.scss
@@ -82,6 +82,7 @@ $padding: 1.5em;
 .activity {
   p {
     margin: 0 0 0 0;
+    white-space: pre-wrap;
   }
   background: white;
   border-radius: $border-radius-base;

--- a/js/apps/shared/utils/handlebarsHelpers.js
+++ b/js/apps/shared/utils/handlebarsHelpers.js
@@ -295,6 +295,6 @@ define(function (require) {
         cause unnecessary length to the activity feed, so trim any 4+
         line breaks to 3.
       **/
-      return summary.replace(/\n\s*\n\s*\n\s*\n/g, '\n\n\n');
+      return summary.replace(/\n\s*\n\s*\n/g, '\n\n');
     });
 });

--- a/js/apps/shared/utils/handlebarsHelpers.js
+++ b/js/apps/shared/utils/handlebarsHelpers.js
@@ -287,5 +287,14 @@ define(function (require) {
     Handlebars.registerHelper('round', function(value) {
         return Math.round(value);
     });
-});
 
+    Handlebars.registerHelper('trimActivitySummary', function(summary) {
+      /**
+        Agents want to be able to delineate sections of their summary with
+        line breaks. We don't want them to add too many line breaks and
+        cause unnecessary length to the activity feed, so trim any 4+
+        line breaks to 3.
+      **/
+      return summary.replace(/\n\s*\n\s*\n\s*\n/g, '\n\n\n');
+    });
+});

--- a/templates/handlebars/thirdchannel/task.hbs
+++ b/templates/handlebars/thirdchannel/task.hbs
@@ -33,7 +33,11 @@
     <div class="summary">
         {{#show_summary}}
             <h3>{{../subject}}</h3>
-            <p>{{{../content}}}</p>
+            {{#if_eq type "Checkin"}}
+              <p>{{{trimActivitySummary ../content}}}</p>
+            {{else}}
+              <p>{{{../content}}}</p>
+            {{/if_eq}}
         {{else}}
             <h3>There is no Summary for this {{../name}}.</h3>
         {{/show_summary}}


### PR DESCRIPTION
**What:** Only ever display a max of two line breaks between paragraphs in activity summaries.

**Why:** Some clients want particularly sectioned summaries from agent. We're already storing summaries with line breaks, so we only had to enable support for them. However, we want to make sure agents aren't abusing line breaks that would cause unnecessarily long entries in the activity feed. For checkins, we replace any instance 4+ line breaks with 3, which adds two lines of space between paragraphs.

**JIRA:** https://thirdchannel.atlassian.net/browse/PS-613