### PR TITLE
Updated styles on sales breakdown

### DIFF
--- a/css/scss/apps/thirdchannel/_store_profile.scss
+++ b/css/scss/apps/thirdchannel/_store_profile.scss
@@ -52,6 +52,7 @@
 .sales-overview {
   h2 {
     display: inline-block;
+    margin-bottom: .25em;
   }
 
   .subnav {
@@ -64,7 +65,12 @@
     }
 
     p {
+      margin: .25em 0;
       order: 2;
+    }
+
+    &:first-child {
+      margin-top: 1em;
     }
   }
 }
@@ -74,9 +80,15 @@
     .overview-data {
 
       h2 {
+        margin: .25em 0;
         order: 2;
-        margin: 1em 0;
         text-align: right;
+
+        &.percentage-change {
+          margin-bottom: .5em;
+          padding: 0;
+          width: 100%;
+        }
       }
 
       p {

--- a/templates/handlebars/thirdchannel/store_profile/sales/chart_breakdowns.hbs
+++ b/templates/handlebars/thirdchannel/store_profile/sales/chart_breakdowns.hbs
@@ -2,12 +2,12 @@
     <div class="pure-g">
         <div class="col-md-1-1 col-1-2" id="brand-percent-of-sales">
             <h3>% of Sales By {{breakdown_by}}</h3>
-            <p>This period</p>
+            <span class="sub-header">This period</span>
             <div class="chart"></div>
         </div>
         <div class="col-md-1-1 col-1-2" id="brand-change-in-sales">
             <h3>% Change in Sales</h3>
-            <p>Compared to this period previous year</p>
+            <span class="sub-header">Compared to this period previous year</span>
             <div class="chart horizontal-bar"></div>
         </div>
         <div class="col-1-1">

--- a/templates/handlebars/thirdchannel/store_profile/sales/overview.hbs
+++ b/templates/handlebars/thirdchannel/store_profile/sales/overview.hbs
@@ -1,11 +1,12 @@
 <section class="section data-section sales-overview">
     <div class="pure-g">
-        <h2 class="col-1-2">Overview</h2>
+        <h2 class="col-1-2 overview-header">Overview</h2>
         <span class="col-1-2 subnav">
             <a href="#" class="prev-quarter"> < <span class="hidden-md">Previous Quarter</span></a>
             Q{{current_time_period}} - {{current_year}}
             <a href="#" class="next-quarter"><span class="hidden-md">Next Quarter</span> > </a>
         </span>
+        <span class="sub-header col-1-1">Compared to this period last year</span>
         <div class="col-md-1 col-1-4">
             <div class="pure-g overview-data">
                 <h2 class="col-md-1-2 col-1">{{formatSalesDollarValue accountSalesInCents}}</h2>
@@ -15,7 +16,6 @@
                 <h2 class="col-md-1-2 col-1 percentage-change overview-qtd {{ percentageChangeClass accountSalesChange }}">
                     <i class="fa {{ percentageChangeIcon accountSalesChange }}"></i> {{formatPercentageChange accountSalesChange}}
                 </h2>
-                <p class="col-md-1-2 col-1">Compared to this period last year</p>
             </div>
         </div>
         <div class="col-md-1-1 col-1-4">
@@ -27,7 +27,6 @@
                 <h2 class="col-md-1-2 col-1 percentage-change overview-qtd {{ percentageChangeClass salesChange }}">
                     <i class="fa {{ percentageChangeIcon salesChange }}"></i> {{formatPercentageChange salesChange}}
                 </h2>
-                <p class="col-md-1-2 col-1">Compared to this period last year</p>
             </div>
         </div>
         <div class="col-md-1-1 col-1-4">
@@ -39,7 +38,6 @@
                 <h2 class="col-md-1-2 col-1 percentage-change overview-qtd {{ percentageChangeClass unitsSoldChange }}">
                     <i class="fa {{ percentageChangeIcon unitsSoldChange }}"></i> {{formatPercentageChange unitsSoldChange}}
                 </h2>
-                <p class="col-md-1-2 col-1">Compared to this period last year</p>
             </div>
         </div>
         <div class="col-md-1-1 col-1-4">
@@ -51,7 +49,6 @@
                 <h2 class="col-md-1-2 col-1 percentage-change overview-qtd {{ percentageChangeClass unitsOnHandChange }}">
                     <i class="fa {{ percentageChangeIcon unitsOnHandChange }}"></i> {{formatPercentageChange unitsOnHandChange}}
                 </h2>
-                <p class="col-md-1-2 col-1">Compared to this period last year</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
**What:** Modifying the styling on the store sales overview.

**Why:** To decrease repetition and to make things look more consistent across the page.

**Jira:** https://thirdchannel.atlassian.net/browse/TC-4851

**Before**
<img width="1455" alt="screen shot 2016-12-28 at 1 56 19 pm" src="https://cloud.githubusercontent.com/assets/579649/21529141/81416cde-cd05-11e6-9211-b9e58562e3eb.png">


**After**
<img width="1148" alt="screen shot 2016-12-28 at 1 46 45 pm" src="https://cloud.githubusercontent.com/assets/579649/21529114/5239d9d0-cd05-11e6-86f9-850587164c8c.png">
