### PR TITLE
Add column for schedule to Profile > Stores table

### DIFF
--- a/templates/handlebars/thirdchannel/profiles/stores/rows.hbs
+++ b/templates/handlebars/thirdchannel/profiles/stores/rows.hbs
@@ -8,6 +8,9 @@
       {{#if rows.0.distance}}
         <th>Distance</th>
       {{/if}}
+      {{#if rows.0.links.schedule}}
+        <th>Schedule</th>
+      {{/if}}
       {{#if rows.0.sales_data}}
         <th>Sales</th>
       {{/if}}
@@ -18,13 +21,15 @@
       <tr>
         <td>
           <a href="{{ links.profile }}">{{name}}</a>
-        {{#if links.schedule}}
-          <a href="{{links.schedule}}" target="_blank" title="View Store Schedule"><i class="ic ic_calendar"></i></a>
-        {{/if}}
         </td>
         <td>{{address}}</td>
       {{#if distance}}
         <td>{{distance}} miles</td>
+      {{/if}}
+      {{#if links.schedule}}
+        <td>
+          <a href="{{links.schedule}}" target="_blank" title="View Store Schedule"><i class="ic ic_calendar"></i> Schedule</a>
+        </td>
       {{/if}}
       {{#if sales_data}}
         <td>


### PR DESCRIPTION
**What:** Add a new column to the table to display a link to the user's schedule for that store.

**Why:** How it was originally designed, and is easier to find.

**Jira:** https://thirdchannel.atlassian.net/browse/PS-626

<img width="1460" alt="screen shot 2016-12-28 at 2 55 17 pm" src="https://cloud.githubusercontent.com/assets/579649/21530490/26f6cd14-cd0f-11e6-84f0-46c9ba91d87b.png">
