### PR TITLE
Refactoring Profile > Stores table to use responsive collapsed table layout

### DIFF
--- a/css/scss/apps/thirdchannel/_scheduled_visits.scss
+++ b/css/scss/apps/thirdchannel/_scheduled_visits.scss
@@ -4,3 +4,9 @@
 .scheduled-visit-cell {
 	padding: 0 0.5em;
 }
+.view-schedule {
+	@include swb-medium {
+		display: inline-block;
+		padding: 1em 0 1.5em;
+	}
+}

--- a/templates/handlebars/thirdchannel/profiles/stores/rows.hbs
+++ b/templates/handlebars/thirdchannel/profiles/stores/rows.hbs
@@ -1,57 +1,58 @@
 {{#if rows}}
-<div class="section">
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Store Name</th>
-        <th>Address</th>
+  <div class="header">
+    <div class="pure-g">
+      <h3 class="col-md-1 col-1-5">Store</h3>
+      <h3 class="col-1-3 hidden-md">Address</h3>
       {{#if rows.0.distance}}
-        <th>Distance</th>
+        <h3 class="col-1-7 hidden-md">Distance</h3>
       {{/if}}
       {{#if rows.0.links.schedule}}
-        <th>Schedule</th>
+        <h3 class="col-1-7 hidden-md">Schedule</h3>
       {{/if}}
       {{#if rows.0.sales_data}}
-        <th>Sales</th>
+        <h3 class="col-1-7 hidden-md">Sales</h3>
       {{/if}}
-      </tr>
-    </thead>
-    <tbody>
+    </div>
+  </div>
+  <div class="body">
     {{#rows}}
-      <tr>
-        <td>
-          <a href="{{ links.profile }}">{{name}}</a>
-        </td>
-        <td>{{address}}</td>
-      {{#if distance}}
-        <td>{{distance}} miles</td>
-      {{/if}}
-      {{#if links.schedule}}
-        <td>
-          <a href="{{links.schedule}}" target="_blank" title="View Store Schedule"><i class="ic ic_calendar"></i> Schedule</a>
-        </td>
-      {{/if}}
-      {{#if sales_data}}
-        <td>
-        {{#if sales_data.message}}
-          <span>
-            <i class="medium-blue">{{sales_data.message}}</i>
-          </span>
-        {{else}}
-          <span class="sales-button">
-            <a href="{{links.profile}}/sales" class="percentage-change activity-feed-qtd {{ percentageChangeClass sales_data.sales_change }}">
-              <i class="fa {{percentageChangeIcon sales_data.sales_change }} change-icon"></i>
-              <div class="pull-right">{{formatPercentageChange sales_data.sales_change}}</div>
-            </a>
-          </span>
-        {{/if}}
-        </td>
-      {{/if}}
-      </tr>
+      <div class="item pure-g">
+          <div class="col-md-1 col-1-5">
+            <a href="{{ links.profile }}">{{name}}</a>
+          </div>
+          <div class="col-md-1 col-1-3">
+            {{address}}
+          </div>
+          {{#if distance}}
+            <div class="col-md-1 col-1-7">
+              {{distance}} miles
+            </div>
+          {{/if}}
+          {{#if links.schedule}}
+            <div class="col-md-1 col-1-7">
+              <a href="{{links.schedule}}" target="_blank" title="View Store Schedule"><i class="ic ic_calendar"></i> Schedule</a>
+            </div>
+          {{/if}}
+
+          {{#if sales_data}}
+            <div class="col-md-1 col-1-7">
+              {{#if sales_data.message}}
+              <span>
+                  <i class="medium-blue">{{sales_data.message}}</i>
+              </span>
+              {{else}}
+                  <span class="sales-button">
+                  <a href="{{links.profile}}/sales" class="percentage-change activity-feed-qtd {{ percentageChangeClass sales_data.sales_change }}">
+                      <i class="fa {{percentageChangeIcon sales_data.sales_change }} change-icon"></i>
+                      <div class="pull-right">{{formatPercentageChange sales_data.sales_change}}</div>
+                  </a>
+              </span>
+              {{/if}}
+            </div>
+          {{/if}}
+      </div>
     {{/rows}}
-    </tbody>
-  </table>
-</div>
+  </div>
 {{else}}
-<div class="alert info">No stores are assigned.</div>
+  <div class="alert info">No stores are assigned.</div>
 {{/if}}

--- a/templates/handlebars/thirdchannel/profiles/stores/rows.hbs
+++ b/templates/handlebars/thirdchannel/profiles/stores/rows.hbs
@@ -30,7 +30,7 @@
           {{/if}}
           {{#if links.schedule}}
             <div class="col-md-1 col-1-7">
-              <a href="{{links.schedule}}" target="_blank" title="View Store Schedule"><i class="ic ic_calendar"></i> Schedule</a>
+              <a class="view-schedule" href="{{links.schedule}}" target="_blank" title="View Store Schedule"><i class="ic ic_calendar"></i> Schedule</a>
             </div>
           {{/if}}
 


### PR DESCRIPTION
**Dependency:** https://github.com/RSV2/ThirdChannel/pull/439

**What:** Switched the Profile > Stores table layout to use the existing responsively-friendly version (as seen on the Stores listing).

**Why:** In adding an additional column to this table, the smaller screen layout was getting jumbled. This now displays in a more user-friendly way on smaller devices.

**Jira:** https://thirdchannel.atlassian.net/browse/PS-626

**Before**
<img width="611" alt="screen shot 2017-01-04 at 1 42 46 pm" src="https://cloud.githubusercontent.com/assets/579649/21654713/cb10062a-d284-11e6-952a-3d8f1581a865.png">

**After**
<img width="609" alt="screen shot 2017-01-04 at 1 43 00 pm" src="https://cloud.githubusercontent.com/assets/579649/21654719/d0a16b60-d284-11e6-97f5-b05d2bdab6ac.png">
