### PR TITLE
Display per-store sales data date on activity feed and on store reports

### DIFF
--- a/css/scss/apps/thirdchannel/_activities.scss
+++ b/css/scss/apps/thirdchannel/_activities.scss
@@ -5,6 +5,17 @@ $padding: 1.5em;
   $padding: 1em;
 }
 
+.through-date {
+  color: $medium-blue;
+  font-size: .95em;
+  font-style: italic;
+  text-align: right;
+
+  @include swb-small {
+    text-align: left;
+  }
+}
+
 .activity-holder {
   margin-bottom: 1.5em;
   border-radius: $border-radius-base;
@@ -153,7 +164,7 @@ $padding: 1.5em;
   .sales-widget {
     vertical-align: top;
     display: inline-block;
-    line-height: 3.25em;
+    line-height: 1.75em;
     float:right !important;
 
     .sales-message {
@@ -163,6 +174,7 @@ $padding: 1.5em;
 
     .sales-button {
       padding-left: 1em;
+      float: right;
 
       .change-icon {
         font-size: 1em;

--- a/js/apps/shared/utils/handlebarsHelpers.js
+++ b/js/apps/shared/utils/handlebarsHelpers.js
@@ -199,7 +199,7 @@ define(function (require) {
         });
     });
 
-    Handlebars.registerHelper('formatSecondsToDate', function(seconds, locale) {
+    Handlebars.registerHelper('formatSecondsToDateTime', function(seconds, locale) {
         if(locale === undefined) {
             locale = 'en-US';
         }
@@ -216,13 +216,35 @@ define(function (require) {
             month: "long",
             day: "numeric"
         }),
-            timeString = date.toLocaleTimeString(locale, {
-                hour: "2-digit",
-                minute: "2-digit",
-                timeZoneName: "short"
-            });
+
+        timeString = date.toLocaleTimeString(locale, {
+            hour: "2-digit",
+            minute: "2-digit",
+            timeZoneName: "short"
+        });
 
         return dateString + ' at ' + timeString;
+    });
+
+    Handlebars.registerHelper('formatDateToLongDate', function(utcDate, locale) {
+        if (locale === undefined) {
+            locale = 'en-US';
+        }
+
+        var date = new Date(utcDate);
+
+        var offset = date.getTimezoneOffset()  / 60;
+        var hours = date.getHours();
+
+        date.setHours(hours - offset);
+
+        var dateString = date.toLocaleDateString(locale, {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        });
+
+        return dateString;
     });
 
     Handlebars.registerHelper('similarAccountClass', function(similarity) {

--- a/js/apps/thirdchannel/registries/activities/store_sales.js
+++ b/js/apps/thirdchannel/registries/activities/store_sales.js
@@ -6,7 +6,7 @@ define(function(require) {
 
         /**
          *  A Regisitry for storing sales figures for programStores. Responsible for receiving registration events
-         * 
+         *
          * @type {View}
          */
         StoreSalesRegistry = Backbone.View.extend({
@@ -21,10 +21,10 @@ define(function(require) {
                     return false;
                 }
                 this.feedUrl = context.links.sales;
-                
-                // watch the context event emitter, register each uuid, buffer them in groups by time, 
-                // then query for sales data 
-                
+
+                // watch the context event emitter, register each uuid, buffer them in groups by time,
+                // then query for sales data
+
                 rx.Observable.fromEvent(context, "store.sales.register")
                 .map(function(uuid) {return self.register(uuid); })
                 .buffer(function () { return Rx.Observable.timer(self.bufferFrequency); })
@@ -55,7 +55,7 @@ define(function(require) {
                 .map(function (data) {
                     var arr = [];
                     for (var uuid in data.sales) {
-                        arr.push({uuid: uuid, salesChange: data.sales[uuid].sales_change, message: data.sales[uuid].message});
+                        arr.push({uuid: uuid, salesChange: data.sales[uuid].sales_change, message: data.sales[uuid].message, mostRecent: data.sales[uuid].mostRecent});
                     }
                     return arr;
                 })

--- a/js/apps/thirdchannel/views/activities/activity.js
+++ b/js/apps/thirdchannel/views/activities/activity.js
@@ -60,7 +60,7 @@ define(function(require) {
             } else {
                 this.model.set('imageCount', 0);
             }
-            
+
             this.model.set('singleActivity', this.options.singleActivity);
             this.model.set('isMobile', helpers.isMobile.any());
 
@@ -245,7 +245,7 @@ define(function(require) {
             if (location && location.hasOwnProperty('id') && location.id === event.uuid) {
                 // only show values with 0 or greater?
                 var data = {salesChange: event.salesChange, showLabel: event.value ? true : false,
-                    salesUrl: event.salesUrl, message: event.message};
+                    salesUrl: event.salesUrl, message: event.message, mostRecent: event.mostRecent};
                 this.$el.find('.activity-meta').append(HandlebarsTemplates['thirdchannel/activities/sales_widget'](data));
                 this.$el.find('.sales-widget').fadeIn(500).css("display","inline-block");
             }

--- a/templates/handlebars/thirdchannel/activities/sales_widget.hbs
+++ b/templates/handlebars/thirdchannel/activities/sales_widget.hbs
@@ -13,6 +13,7 @@
             {{formatPercentageChange salesChange}}
         </a>
     </span>
+    <div class="through-date">through {{formatDateToLongDate mostRecent}}</div>
   {{/if}}
   </div>
 </section>

--- a/templates/handlebars/thirdchannel/activity.hbs
+++ b/templates/handlebars/thirdchannel/activity.hbs
@@ -16,7 +16,7 @@
                 </p>
                 {{/if_eq}}
                 <p>
-                    <span><i class="timestamp" data-livestamp="{{created_at}}"></i></span> <span>({{formatSecondsToDate created_at}})</span>
+                    <span><i class="timestamp" data-livestamp="{{created_at}}"></i></span> <span>({{formatSecondsToDateTime created_at}})</span>
                     by
                     <a href="/programs/{{current_program}}/profiles/{{user_id}}">{{user_name}}</a>
                 </p>

--- a/templates/handlebars/thirdchannel/store_profile/sales/overview.hbs
+++ b/templates/handlebars/thirdchannel/store_profile/sales/overview.hbs
@@ -6,7 +6,7 @@
             Q{{current_time_period}} - {{current_year}}
             <a href="#" class="next-quarter"><span class="hidden-md">Next Quarter</span> > </a>
         </span>
-        <span class="sub-header col-1-1">Compared to this period last year</span>
+        <span class="sub-header col-1-1">Compared to this period last year through {{formatDateToLongDate mostRecent}}</span>
         <div class="col-md-1 col-1-4">
             <div class="pure-g overview-data">
                 <h2 class="col-md-1-2 col-1">{{formatSalesDollarValue accountSalesInCents}}</h2>


### PR DESCRIPTION
**What:** Add a new display element to the sales widget that shows a store's latest sales data date, as well as amend copy on a store's report to show the latest sales data date.

**Why:** So users know the latest data we have available for the store.

**Jira:** https://thirdchannel.atlassian.net/browse/PS-602

**Through date display on Activity feed**
<img width="1343" alt="activity-feed" src="https://cloud.githubusercontent.com/assets/579649/21772871/ff97a16c-d65a-11e6-8fc6-e1bded4023cd.png">

**Through date displayed as part of subheader on store report**
<img width="1457" alt="screen shot 2017-01-09 at 10 31 17 am" src="https://cloud.githubusercontent.com/assets/579649/21772888/0dd7eeb2-d65b-11e6-9639-91f1483cc739.png">

