### PR TITLE
Hide widget "View Breakdown" links on Labs

### DIFF
--- a/css/scss/apps/thirdchannel/_labs.scss
+++ b/css/scss/apps/thirdchannel/_labs.scss
@@ -69,6 +69,10 @@
     font-size: 0.65em;
     padding-right: 0.5rem;
   }
+
+  .breakdown-link {
+    display: none;
+  }
 }
 
 


### PR DESCRIPTION
**What:** Hide the "View Breakdown" link that appears on chart widgets on the Labs page.

**Why:** The page this link brings you to is not really reflective of what the Labs page aims to illustrate, so it makes more sense to remove it.

**Jira:** https://thirdchannel.atlassian.net/browse/TC-4263