### PR TITLE
[SD-258] Calculate sales chart height based on data

### DIFF
--- a/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
+++ b/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
@@ -21,6 +21,7 @@ define(function(require) {
         renderSalesPerBreakdown: function() {
             var store = this.model.get('store');
             var breakdowns = [];
+            var graphHeight;
 
             if(this.model.get('breakdown_by') === 'category') {
                 breakdowns = store.categories;
@@ -35,6 +36,8 @@ define(function(require) {
             });
             breakdowns = _.filter(breakdowns, function(data) { return data.percentageOfSales !== null; });
             breakdowns = _.sortBy(breakdowns, 'percentageOfSales').reverse();
+
+            graphHeight = this.getMaxGraphHeight(breakdowns.length);
 
             this.salesPerCategoryChart = c3.generate({
                 bindto: this.$('#brand-percent-of-sales > .chart')[0],
@@ -101,7 +104,7 @@ define(function(require) {
                     show: false
                 },
                 size: {
-                    height: 360
+                    height: graphHeight
                 }
             });
         },
@@ -109,6 +112,7 @@ define(function(require) {
         renderChangeInSales: function() {
             var store = this.model.get('store');
             var breakdowns = [];
+            var graphHeight;
 
             if(this.model.get('breakdown_by') === 'category') {
                 breakdowns = store.categories;
@@ -122,6 +126,8 @@ define(function(require) {
             });
             breakdowns = _.filter(breakdowns, function(data) { return data.percentageOfSales !== null; });
             breakdowns = _.sortBy(breakdowns, 'percentageOfSales').reverse();
+
+            graphHeight = this.getMaxGraphHeight(breakdowns.length);
 
             this.changeInSalesChart = c3.generate({
                 bindto: this.$('#brand-change-in-sales > .chart')[0],
@@ -188,9 +194,20 @@ define(function(require) {
                     show: false
                 },
                 size: {
-                    height: 360
+                    height: graphHeight
                 }
             });
+        },
+
+        getMaxGraphHeight: function(itemLength) {
+          /* 360 = default chart height
+           * 32 = the height of the bar chart (30) + 2 px on either side
+           * for the tick markers that the bars fit between
+           *
+           * This means that when charts get larger than 360px,
+           * the bars will be back to back and not overlapping.
+           */
+          return (itemLength * 32) > 360 ? (itemLength * 32) : 360;
         }
     });
 

--- a/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
+++ b/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
@@ -201,13 +201,14 @@ define(function(require) {
 
         getMaxGraphHeight: function(itemLength) {
           /* 360 = default chart height
-           * 32 = the height of the bar chart (30) + 2 px on either side
-           * for the tick markers that the bars fit between
+           * 36 = the height of the bar chart (30) + 2 px on either side
+           * for the tick markers that the bars fit between, as well as 4px
+           * additional spacing between rows.
            *
            * This means that when charts get larger than 360px,
            * the bars will be back to back and not overlapping.
            */
-          return (itemLength * 32) > 360 ? (itemLength * 32) : 360;
+          return Math.max(itemLength * 36, 360);
         }
     });
 


### PR DESCRIPTION
**What:** Change how we calculate the height of the sales data graphs to be based on how many items are in the Y axis.

**Why:** These charts were set to a permanent 360px height. Wilson's data does not fit into this height so all the bars were overlapping. We now calculate the height of the chart by seeing if the data would display properly within the 360 limit. If not, we calculate what the minimum needed height is and use that value.

**Jira:** https://thirdchannel.atlassian.net/browse/SD-258

**Before**
<img width="1436" alt="screen shot 2017-01-10 at 10 14 23 am" src="https://cloud.githubusercontent.com/assets/579649/21811409/9da31842-d71d-11e6-906e-b6331b0b3c92.png">


**After**
<img width="741" alt="screen shot 2017-01-11 at 10 26 51 am" src="https://cloud.githubusercontent.com/assets/579649/21854605/5e71c9bc-d7e9-11e6-9a37-62ad88cccc2d.png">

