### PR TITLE
[SD-277] Sort sales breakdown table alphabetically

### DIFF
--- a/js/apps/thirdchannel/views/store_profile/sales/breakdown.js
+++ b/js/apps/thirdchannel/views/store_profile/sales/breakdown.js
@@ -21,7 +21,9 @@ define(function(require) {
 
         renderBreakdownGroups: function() {
             var $body = this.$('.body');
-            this.collection.each(function(breakdownGroup) {
+            var sortedCollection = new Backbone.Collection(this.collection.sortBy('brand'));
+
+            sortedCollection.each(function(breakdownGroup) {
                 breakdownGroup.breakdowns.each(function(breakdown, index) {
                     breakdown.set('index', index);
                     var view = new BreakdownRow({model: breakdown});


### PR DESCRIPTION
**What:** Sort the sales breakdown chart alphabetically

**Why:** So it's easier to read through.

Within each brand, the categories are already sorted alphabetically, so we only have to sort the top level ourselves.

**Jira:** https://thirdchannel.atlassian.net/browse/SD-277