### PR TITLE
Dont compensate for timezone when displaying sales data date

### DIFF
--- a/js/apps/shared/utils/handlebarsHelpers.js
+++ b/js/apps/shared/utils/handlebarsHelpers.js
@@ -2,7 +2,8 @@ define(function (require) {
 
     var $ = require('jquery'),
         _ = require('underscore'),
-        Handlebars = require('handlebars');
+        Handlebars = require('handlebars'),
+        moment = require('moment');
 
     Handlebars.registerHelper('if_eq', function (a, b, opts) {
         if (a == b) // Or === depending on your needs
@@ -227,24 +228,7 @@ define(function (require) {
     });
 
     Handlebars.registerHelper('formatDateToLongDate', function(utcDate, locale) {
-        if (locale === undefined) {
-            locale = 'en-US';
-        }
-
-        var date = new Date(utcDate);
-
-        var offset = date.getTimezoneOffset()  / 60;
-        var hours = date.getHours();
-
-        date.setHours(hours - offset);
-
-        var dateString = date.toLocaleDateString(locale, {
-            year: "numeric",
-            month: "long",
-            day: "numeric"
-        });
-
-        return dateString;
+        return moment.utc(utcDate).format('MMMM D, YYYY');
     });
 
     Handlebars.registerHelper('similarAccountClass', function(similarity) {

--- a/js/apps/shared/utils/handlebarsHelpers.js
+++ b/js/apps/shared/utils/handlebarsHelpers.js
@@ -2,8 +2,7 @@ define(function (require) {
 
     var $ = require('jquery'),
         _ = require('underscore'),
-        Handlebars = require('handlebars'),
-        moment = require('moment');
+        Handlebars = require('handlebars');
 
     Handlebars.registerHelper('if_eq', function (a, b, opts) {
         if (a == b) // Or === depending on your needs
@@ -228,7 +227,19 @@ define(function (require) {
     });
 
     Handlebars.registerHelper('formatDateToLongDate', function(utcDate, locale) {
-        return moment.utc(utcDate).format('MMMM D, YYYY');
+        if (locale === undefined) {
+            locale = 'en-US';
+        }
+
+        var dateString = utcDate.split(" ")[0];
+        var date = new Date(dateString);
+        date.setDate(date.getDate() + 1);
+
+        return date.toLocaleDateString(locale, {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        });
     });
 
     Handlebars.registerHelper('similarAccountClass', function(similarity) {


### PR DESCRIPTION
**What:** Change `formatDateToLongDate` to display the UTC time and not calculate the offset for the local timezone.

**Why:** It makes more sense for customers when looking at sales data.

**Jira:** https://thirdchannel.atlassian.net/browse/SD-278