### PR TITLE
SD-260 - Backend now has Upper Case Categories, so Title cased all the category labels

### DIFF
--- a/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
+++ b/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
@@ -29,9 +29,12 @@ define(function(require) {
             }
 
             breakdowns = _.map(breakdowns, function(data, key) {
-                data.label = key;
-                data.percentageOfSales = (data.salesInCents / store.salesInCents) * 100;
-                return data;
+                        //Title Case the labels
+                        data.label = key.split(' ').map(function(s){
+                            return s.length <=1 ? s.toUpperCase() : s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+                        }).join(" ");
+                        data.percentageOfSales = (data.salesInCents / store.salesInCents) * 100;
+                        return data;
             });
             breakdowns = _.filter(breakdowns, function(data) { return data.percentageOfSales !== null; });
             breakdowns = _.sortBy(breakdowns, 'percentageOfSales').reverse();
@@ -117,7 +120,9 @@ define(function(require) {
             }
 
             breakdowns = _.map(breakdowns, function(data, key) {
-                data.label = key;
+                data.label = key.split(' ').map(function(s){
+                    return s.length <=1 ? s.toUpperCase() : s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+                }).join(" ");
                 return data;
             });
             breakdowns = _.filter(breakdowns, function(data) { return data.percentageOfSales !== null; });

--- a/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
+++ b/js/apps/thirdchannel/views/store_profile/sales/chart_breakdowns.js
@@ -8,6 +8,12 @@ define(function(require) {
 
     var defaultLegendColors = ["#F15F51", "#585E60", "#9FB2C0", "#A9BC4D"];
 
+    var titleizeString = function(text) {
+        return text.split(' ').map(function(s){
+            return s.length <=1 ? s.toUpperCase() : s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+        }).join(" ");
+    };
+
     var View = Backbone.View.extend({
         template: HandlebarsTemplates['thirdchannel/store_profile/sales/chart_breakdowns'],
 
@@ -17,6 +23,8 @@ define(function(require) {
             this.renderChangeInSales();
             return this;
         },
+
+
 
         renderSalesPerBreakdown: function() {
             var store = this.model.get('store');
@@ -30,9 +38,7 @@ define(function(require) {
 
             breakdowns = _.map(breakdowns, function(data, key) {
                         //Title Case the labels
-                        data.label = key.split(' ').map(function(s){
-                            return s.length <=1 ? s.toUpperCase() : s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-                        }).join(" ");
+                        data.label = titleizeString(key);
                         data.percentageOfSales = (data.salesInCents / store.salesInCents) * 100;
                         return data;
             });
@@ -120,9 +126,7 @@ define(function(require) {
             }
 
             breakdowns = _.map(breakdowns, function(data, key) {
-                data.label = key.split(' ').map(function(s){
-                    return s.length <=1 ? s.toUpperCase() : s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-                }).join(" ");
+                data.label = titleizeString(key);
                 return data;
             });
             breakdowns = _.filter(breakdowns, function(data) { return data.percentageOfSales !== null; });
@@ -197,6 +201,7 @@ define(function(require) {
                 }
             });
         }
+
     });
 
     return View;

--- a/js/apps/thirdchannel/views/store_profile/sales/report_layout.js
+++ b/js/apps/thirdchannel/views/store_profile/sales/report_layout.js
@@ -134,7 +134,12 @@ define(function(require) {
             } else if(label === 'woman') {
                 label = "Women's";
             }
-            return label;
+
+
+            //Title Case the labels
+            return label.split(' ').map(function(s){
+                return s.length <=1 ? s.toUpperCase() : s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+            }).join(" ");
         }
     });
 


### PR DESCRIPTION
**What**
The labels of all the brands/categories are now Title Cased. This excludes the bold label in the graph below. 

** Why **
Wilson's Item Master has many different casings. We standardized them on the back end but they are in all caps. That looks ugly. 

Jira: https://thirdchannel.atlassian.net/browse/SD-260


![screen shot 2017-01-11 at 1 21 21 pm](https://cloud.githubusercontent.com/assets/10944406/21860953/e7136ab6-d800-11e6-9d16-de7f54f2aa61.png)
