### PR TITLE
[SD-259] Add ability to hide sales overview breakdown table for programs

### DIFF
--- a/js/apps/thirdchannel/views/store_profile/sales/report_layout.js
+++ b/js/apps/thirdchannel/views/store_profile/sales/report_layout.js
@@ -22,7 +22,9 @@ define(function(require) {
         render: function() {
             this.renderOverview();
             this.renderCharts();
-            this.renderOverviewBreakdown();
+            if (this.model.get('view_sales_overview_breakdown')) {
+              this.renderOverviewBreakdown();
+            }
             this.renderBrandsBreakdown();
             return this;
         },


### PR DESCRIPTION
**Dependency:** https://github.com/RSV2/ThirdChannel/pull/448

**What:** Look for a new key in the bootstrap payload, `view_sales_overview_breakdown`, to see if we should render this table.

**Why:** Given the nature of their data, Oakley and Wilson want to hide this table since it is redundant data and not very useful. Adding this new property allows us to hide this table for any program that has this property set in the `program_properties` table, a la sales data and labs access.

**Jira:** https://thirdchannel.atlassian.net/browse/SD-259