### PR TITLE
Always show Sales By Category as store sales chart header

### DIFF
--- a/templates/handlebars/thirdchannel/store_profile/sales/breakdown.hbs
+++ b/templates/handlebars/thirdchannel/store_profile/sales/breakdown.hbs
@@ -3,7 +3,7 @@
         <table>
             <thead>
                 <tr>
-                    <td><h3 class="header alternate">{{title}}</h3></td>
+                    <td><h3 class="header alternate">Category</h3></td>
                     <td>
                         <h3 class="header alternate">$ Sales</h3>
                         <span class="sub-header">This Period, TY</span>

--- a/templates/handlebars/thirdchannel/store_profile/sales/chart_breakdowns.hbs
+++ b/templates/handlebars/thirdchannel/store_profile/sales/chart_breakdowns.hbs
@@ -1,7 +1,7 @@
 <section class="section data-section">
     <div class="pure-g">
         <div class="col-md-1-1 col-1-2" id="brand-percent-of-sales">
-            <h3>% of Sales By {{breakdown_by}}</h3>
+            <h3>% of Sales By Category</h3>
             <span class="sub-header">This period</span>
             <div class="chart"></div>
         </div>


### PR DESCRIPTION
**What:** Always show "% Sales By Category" as the header for stores sales data breakdown.

**Why:** It's more flexible than "Brands" and makes enough sense for all clients at this point in time.

Also updated the table that displays below the chart for consistency.

**Jira:** https://thirdchannel.atlassian.net/browse/SD-276

<img width="1441" alt="screen shot 2017-01-16 at 12 58 13 pm" src="https://cloud.githubusercontent.com/assets/579649/21994004/9e918b4e-dbeb-11e6-9a3a-5eb766846f5b.png">
