### PR TITLE
PS-706 - preventing enter presses from deleting the image

### DIFF
--- a/js/apps/shared/views/s3uploader/checkin_image.js
+++ b/js/apps/shared/views/s3uploader/checkin_image.js
@@ -8,7 +8,7 @@ define(function(require) {
         events: {
             "blur input": 'updated',
             'change select': 'updated',
-            "click button": 'deleted'
+            "click .delete-image-btn": 'deleted'
         },
         initialize: function() {
             if(this.model.get('image_type') === 'after') {

--- a/templates/handlebars/shared/s3uploader/checkin_image.hbs
+++ b/templates/handlebars/shared/s3uploader/checkin_image.hbs
@@ -9,7 +9,7 @@
         {{/if}}
     </div>
     <div class="delete">
-        <button class="btn primary"><i class="ic ic_x"></i><span>Delete Image</span></button>
+        <a class="btn primary delete-image-btn" href="#"><i class="ic ic_x"></i><span>Delete Image</span></a>
     </div>
     <div class="description">
         <label>Description:</label>


### PR DESCRIPTION
https://thirdchannel.atlassian.net/browse/PS-706

A little tricky, the survey form itself is wrapped in a submit event (so pressing enter submits the form). Because of that it would also trigger the other buttons on the page.

To prevent the backbone views' confusion, changed the delete image buttons to links so they don't get triggered by submitting.

Also see PR for thirdchannel