### PR TITLE
Show Units OH and Units Sold as part of the $ Data on Activity Feed

### DIFF
--- a/css/scss/apps/thirdchannel/_activities.scss
+++ b/css/scss/apps/thirdchannel/_activities.scss
@@ -209,8 +209,16 @@ $padding: 1.5em;
     padding: 0 1em;
   }
 
+  &.previous {
+    padding: 0;
+  }
+
   &.hidden {
     visibility: hidden;
+  }
+
+  &:focus {
+    outline: none;
   }
 }
 

--- a/css/scss/apps/thirdchannel/_activities.scss
+++ b/css/scss/apps/thirdchannel/_activities.scss
@@ -11,8 +11,8 @@ $padding: 1.5em;
   font-style: italic;
   text-align: right;
 
-  @include swb-small {
-    text-align: left;
+  @include swb-medium {
+    text-align: center;
   }
 }
 
@@ -164,6 +164,13 @@ $padding: 1.5em;
 
   .sales-marquee {
     float: right;
+
+    @include swb-medium{
+      float: none;
+      width: 100%;
+      text-align: center;
+      padding-top: 1em;
+    }
   }
 
   .sales-figure {
@@ -185,6 +192,8 @@ $padding: 1.5em;
   .sales-widget {
     display: inline-block;
     line-height: 1.75em;
+    min-width: 12.5em;
+    text-align: right;
 
     .sales-message {
       line-height: 3.3em;
@@ -200,20 +209,6 @@ $padding: 1.5em;
       }
     }
 
-    @include swb-small {
-      width: 100%;
-      display: block;
-      float:none;
-      margin-top: 1.5rem;
-
-      p {
-        font-size: 0.85rem;
-        vertical-align: middle;
-      }
-      a {
-        font-size: 0.85rem;
-      }
-    }
     .text, .details {
       display: inline-block;
       text-align: center;
@@ -228,6 +223,10 @@ $padding: 1.5em;
       width: 28%;
       vertical-align: middle;
     }
+
+    @include swb-small {
+      text-align: center;
+    }
   }
 
   .bar-body {
@@ -236,7 +235,7 @@ $padding: 1.5em;
     .timestamp {
       color: $medium-blue;
     }
-    @include swb-small {
+    @include swb-medium {
       width: 100%;
     }
   }

--- a/css/scss/apps/thirdchannel/_activities.scss
+++ b/css/scss/apps/thirdchannel/_activities.scss
@@ -30,7 +30,7 @@ $padding: 1.5em;
     display: inline-block;
     width: 100%;
 
-    @include swb-small {
+    @include swb-medium {
       position: relative;
       width: 100%;
 
@@ -64,9 +64,9 @@ $padding: 1.5em;
       background-color: $border-color;
     }
 
-    @include swb-small {
+    @include swb-medium {
+      margin: 0;
       width: 100%;
-      margin: 0em;
     }
   }
 
@@ -158,86 +158,103 @@ $padding: 1.5em;
   }
 }
 
-.activity-meta {
+.activity-header {
+  align-items: center;
   border-bottom: 1px solid $border-color;
-  padding-bottom: $padding;
+  display: flex;
+  justify-content: space-between;
 
-  .sales-marquee {
-    float: right;
-
-    @include swb-medium{
-      float: none;
-      width: 100%;
-      text-align: center;
-      padding-top: 1em;
-    }
-  }
-
-  .sales-figure {
-    display: inline-block;
-    padding: 0 .25em;
-    vertical-align: middle;
-  }
-
-  .marquee-nav {
-    background-color: transparent;
+  @include swb-medium {
     border: 0;
-    color: $medium-blue;
-
-    &.hidden {
-      visibility: hidden;
-    }
+    flex-direction: column;
   }
+}
 
-  .sales-widget {
-    display: inline-block;
-    line-height: 1.75em;
-    min-width: 12.5em;
-    text-align: right;
-
-    .sales-message {
-      line-height: 3.3em;
-      color: $medium-blue;
-    }
-
-    .sales-button {
-      padding-left: 1em;
-      float: right;
-
-      .change-icon {
-        font-size: 1em;
-      }
-    }
-
-    .text, .details {
-      display: inline-block;
-      text-align: center;
-    }
-    .text {
-      width: 70%;
-      &.full {
-        width: 100%;
-      }
-    }
-    .details {
-      width: 28%;
-      vertical-align: middle;
-    }
-
-    @include swb-small {
-      text-align: center;
-    }
-  }
+.activity-meta {
+  padding-bottom: $padding;
+  width: 100%;
 
   .bar-body {
-    width: 55%;
+    width: 85%;
 
     .timestamp {
       color: $medium-blue;
     }
-    @include swb-medium {
+  }
+}
+
+.sales-marquee {
+  min-width: 18.5em;
+
+  @include swb-medium {
+    border-top: 1px solid $border-color;
+    padding-top: 1.5em;
+    text-align: center;
+    width: 100%;
+  }
+}
+
+.sales-figure {
+  display: inline-block;
+  vertical-align: middle;
+  padding: 0 .25em;
+}
+
+.marquee-nav {
+  background-color: transparent;
+  border: 0;
+  color: $medium-blue;
+
+  &.next {
+    padding: 0 1em;
+  }
+
+  &.hidden {
+    visibility: hidden;
+  }
+}
+
+.sales-widget {
+  display: inline-block;
+  line-height: 1.75em;
+  min-width: 12.5em;
+  text-align: right;
+
+  .sales-message {
+    color: $medium-blue;
+    line-height: 3.3em;
+  }
+
+  .sales-button {
+    float: right;
+    padding-left: 1em;
+
+    .change-icon {
+      font-size: 1em;
+    }
+  }
+
+  .text, .details {
+    display: inline-block;
+    text-align: center;
+  }
+
+  .text {
+    display: inline;
+    width: 70%;
+
+    &.full {
       width: 100%;
     }
+  }
+
+  .details {
+    vertical-align: middle;
+    width: 28%;
+  }
+
+  @include swb-small {
+    text-align: center;
   }
 }
 

--- a/css/scss/apps/thirdchannel/_activities.scss
+++ b/css/scss/apps/thirdchannel/_activities.scss
@@ -158,14 +158,33 @@ $padding: 1.5em;
   }
 }
 
-.activity-meta{
+.activity-meta {
   border-bottom: 1px solid $border-color;
   padding-bottom: $padding;
+
+  .sales-marquee {
+    float: right;
+  }
+
+  .sales-figure {
+    display: inline-block;
+    padding: 0 .25em;
+    vertical-align: middle;
+  }
+
+  .marquee-nav {
+    background-color: transparent;
+    border: 0;
+    color: $medium-blue;
+
+    &.hidden {
+      visibility: hidden;
+    }
+  }
+
   .sales-widget {
-    vertical-align: top;
     display: inline-block;
     line-height: 1.75em;
-    float:right !important;
 
     .sales-message {
       line-height: 3.3em;
@@ -200,7 +219,6 @@ $padding: 1.5em;
       text-align: center;
     }
     .text {
-      border-right: 1px solid $light-blue;
       width: 70%;
       &.full {
         width: 100%;

--- a/css/scss/modules/_store_profile_section.scss
+++ b/css/scss/modules/_store_profile_section.scss
@@ -3,10 +3,41 @@
 	.pagination-holder {
 		min-height: 2em;
 	}
+
+  @include swb-large {
+    .item {
+      position: relative;
+    }
+
+    .col-md-1 {
+      width: 51%;
+      word-wrap: break-word;
+    }
+
+    .sales-marquee {
+      border-top: 0;
+      padding-top: .75em;
+      position: absolute;
+      right: 0;
+      top: 0;
+      width: initial;
+    }
+  }
+
+  @include swb-small {
+    .col-md-1 {
+      width: 100%;
+    }
+
+    .sales-marquee {
+      position: relative;
+      width: 100%;
+    }
+  }
 }
 
 .store-profile-section {
-	
+
 	.activity-meta {
 		padding: 0em;
 	}
@@ -26,7 +57,7 @@
 			.expand-indicator {
 				@extend .ic_up;
 			}
-		}				
+		}
 	}
 
 	.carousel {
@@ -81,4 +112,3 @@
 		width: 100%;
 	}
 }
-

--- a/js/apps/thirdchannel/registries/activities/store_sales.js
+++ b/js/apps/thirdchannel/registries/activities/store_sales.js
@@ -55,7 +55,14 @@ define(function(require) {
                 .map(function (data) {
                     var arr = [];
                     for (var uuid in data.sales) {
-                        arr.push({uuid: uuid, salesChange: data.sales[uuid].sales_change, message: data.sales[uuid].message, mostRecent: data.sales[uuid].mostRecent});
+                        arr.push({
+                          uuid: uuid,
+                          salesChange: data.sales[uuid].sales_change,
+                          message: data.sales[uuid].message,
+                          mostRecent: data.sales[uuid].mostRecent,
+                          unitsOnHandChange: data.sales[uuid].unitsOnHandChange,
+                          unitsSoldChange: data.sales[uuid].unitsSoldChange
+                        });
                     }
                     return arr;
                 })

--- a/js/apps/thirdchannel/views/activities/activity.js
+++ b/js/apps/thirdchannel/views/activities/activity.js
@@ -12,7 +12,8 @@ define(function(require) {
         NewCommentView = require('thirdchannel/views/comments/new_comment'),
         Like = require('thirdchannel/models/activities/like'),
         Follow = require('thirdchannel/models/activities/follow'),
-        Viewer = require('viewer');
+        Viewer = require('viewer'),
+        SalesMarquee = require('thirdchannel/views/shared/sales_marquee');
 
     return Backbone.View.extend({
         className: 'activity',
@@ -242,12 +243,22 @@ define(function(require) {
         updateSalesWidget: function (event) {
             var location = this.model.get('location');
             if (location && location.hasOwnProperty('id') && location.id === event.uuid) {
-                // only show values with 0 or greater?
-                var data = {salesChange: event.salesChange, showLabel: event.value ? true : false,
-                    salesUrl: event.salesUrl, message: event.message, mostRecent: event.mostRecent};
-                this.$el.find('.activity-meta').append(HandlebarsTemplates['thirdchannel/activities/sales_widget'](data));
+                var data = this.getSalesWidgetData(event);
+                new SalesMarquee({el: this.$el.find('.sales-marquee'), salesData: data}).render();
                 this.$el.find('.sales-widget').fadeIn(500).css("display","inline-block");
             }
+        },
+
+        getSalesWidgetData: function(salesData) {
+          return {
+            salesChange: salesData.salesChange,
+            unitsOHChange: salesData.unitsOnHandChange,
+            unitsSoldChange: salesData.unitsSoldChange,
+            showLabel: salesData.value ? true : false,
+            salesUrl: salesData.salesUrl,
+            message: salesData.message,
+            mostRecent: salesData.mostRecent
+          }
         }
     });
 });

--- a/js/apps/thirdchannel/views/activities/activity.js
+++ b/js/apps/thirdchannel/views/activities/activity.js
@@ -252,9 +252,8 @@ define(function(require) {
         getSalesWidgetData: function(salesData) {
           return {
             salesChange: salesData.salesChange,
-            unitsOHChange: salesData.unitsOnHandChange,
+            unitsOnHandChange: salesData.unitsOnHandChange,
             unitsSoldChange: salesData.unitsSoldChange,
-            showLabel: salesData.value ? true : false,
             salesUrl: salesData.salesUrl,
             message: salesData.message,
             mostRecent: salesData.mostRecent

--- a/js/apps/thirdchannel/views/activities/activity.js
+++ b/js/apps/thirdchannel/views/activities/activity.js
@@ -244,7 +244,7 @@ define(function(require) {
             var location = this.model.get('location');
             if (location && location.hasOwnProperty('id') && location.id === event.uuid) {
                 var data = this.getSalesWidgetData(event);
-                new SalesMarquee({el: this.$el.find('.sales-marquee'), salesData: data}).render();
+                new SalesMarquee({el: this.$el.find('.sales-marquee'), salesData: data});
                 this.$el.find('.sales-widget').fadeIn(500).css("display","inline-block");
             }
         },
@@ -258,7 +258,7 @@ define(function(require) {
             salesUrl: salesData.salesUrl,
             message: salesData.message,
             mostRecent: salesData.mostRecent
-          }
+          };
         }
     });
 });

--- a/js/apps/thirdchannel/views/shared/sales_marquee.js
+++ b/js/apps/thirdchannel/views/shared/sales_marquee.js
@@ -1,0 +1,83 @@
+define(function(require) {
+    var $ = require('jquery'),
+        _ = require('underscore'),
+        Backbone = require('backbone'),
+        Handlebars = require('handlebars'),
+        HandlebarsTemplates = require('handlebarsTemplates'),
+        HandlebarsHelpers = require('handlebarsHelpers'),
+        context = require('context'),
+        helpers = require('helpers');
+
+
+    return Backbone.View.extend({
+        template: HandlebarsTemplates['thirdchannel/activities/sales_marquee'],
+        salesTemplate: HandlebarsTemplates['thirdchannel/activities/sales_widget'],
+
+        events: {
+          'click .next': 'next',
+          'click .previous': 'previous'
+        },
+
+        initialize: function (data) {
+          this.currentWidget = 0;
+          this.salesData = data.salesData;
+          this.salesWidgets = this.formatSalesWidgets(this.salesData);
+          this.canNavBack = false;
+          this.canNavForward = false;
+        },
+
+        render: function () {
+          this.canNavBack = (this.salesWidgets.length !== 0 && this.currentWidget !== 0);
+          this.canNavForward = (this.salesWidgets.length !== 0 && this.currentWidget !== this.salesWidgets.length - 1);
+
+          var templateData = {
+            showMessage: this.salesData.message && this.salesWidgets.length === 0,
+            message: this.salesData.message,
+            widget: this.salesWidgets[this.currentWidget],
+            salesUrl: this.salesData.salesUrl,
+            mostRecent: this.salesData.mostRecent
+          };
+          this.$el.html(this.template({canNavForward: this.canNavForward, canNavBack: this.canNavBack}));
+          this.$el.find('.sales-figure').append(this.salesTemplate(templateData));
+          // TODO: Don't inline these styles
+          this.$el.find('.sales-marquee').fadeIn(500).css({"display": "inline-block", "float": "right"});
+        },
+
+        formatSalesWidgets: function(salesData) {
+          var widgets = [
+            {
+              label: 'QTD $ Sales',
+              change: salesData.salesChange
+            },
+            {
+              label: 'Units Sold',
+              change: salesData.unitsSoldChange
+            },
+            {
+              label: 'Units OH',
+              change: salesData.unitsOHChange
+            }
+          ];
+
+          return _.filter(widgets, function(widget) {
+            return _.isNumber(widget.change) && widget.change !== 0;
+          });
+        },
+
+        next: function(e) {
+          e.stopPropagation();
+          e.preventDefault();
+
+          this.currentWidget = this.currentWidget + 1;
+          this.render();
+        },
+
+        previous: function(e) {
+          e.stopPropagation();
+          e.preventDefault();
+
+          this.currentWidget = this.currentWidget - 1;
+          this.render();
+        }
+    });
+});

--- a/js/apps/thirdchannel/views/shared/sales_marquee.js
+++ b/js/apps/thirdchannel/views/shared/sales_marquee.js
@@ -3,10 +3,7 @@ define(function(require) {
         _ = require('underscore'),
         Backbone = require('backbone'),
         Handlebars = require('handlebars'),
-        HandlebarsTemplates = require('handlebarsTemplates'),
-        HandlebarsHelpers = require('handlebarsHelpers'),
-        context = require('context'),
-        helpers = require('helpers');
+        HandlebarsTemplates = require('handlebarsTemplates');
 
 
     return Backbone.View.extend({
@@ -24,6 +21,8 @@ define(function(require) {
           this.salesWidgets = this.formatSalesWidgets(this.salesData);
           this.canNavBack = false;
           this.canNavForward = false;
+
+          this.render();
         },
 
         render: function () {
@@ -37,10 +36,9 @@ define(function(require) {
             salesUrl: this.salesData.salesUrl,
             mostRecent: this.salesData.mostRecent
           };
+
           this.$el.html(this.template({canNavForward: this.canNavForward, canNavBack: this.canNavBack}));
           this.$el.find('.sales-figure').append(this.salesTemplate(templateData));
-          // TODO: Don't inline these styles
-          this.$el.find('.sales-marquee').fadeIn(500).css({"display": "inline-block", "float": "right"});
         },
 
         formatSalesWidgets: function(salesData) {

--- a/js/apps/thirdchannel/views/shared/sales_marquee.js
+++ b/js/apps/thirdchannel/views/shared/sales_marquee.js
@@ -53,7 +53,7 @@ define(function(require) {
             },
             {
               label: 'Units OH',
-              change: salesData.unitsOHChange
+              change: salesData.unitsOnHandChange
             }
           ];
 

--- a/js/apps/thirdchannel/views/stores/list.js
+++ b/js/apps/thirdchannel/views/stores/list.js
@@ -1,15 +1,30 @@
 define(function(require) {
-    var PageableListView = require('thirdchannel/views/shared/pageable_list'),
+    var $ = require('jquery'),
+        context = require('context'),
+        PageableListView = require('thirdchannel/views/shared/pageable_list'),
+        SalesMarquee = require('thirdchannel/views/shared/sales_marquee'),
+
         /**
          *
          * The Stores list
-         * 
+         *
          * @extends {module:thirdchannel/views/shared/pageable_list}
          * @exports thirdchannel/views/stores/list
          */
         StoreListView = PageableListView.extend({
             el: '#stores',
             template: 'thirdchannel/stores/rows',
+
+            afterRender: function(options) {
+              var self = this;
+              PageableListView.prototype.afterRender.apply(this, [options]);
+
+              this.collection.forEach(function(model) {
+                if (model.get('sales_data')) {
+                  new SalesMarquee({el: self.$el.find('.sales-marquee#' + model.get('id')), salesData: model.get('sales_data')});
+                }
+              });
+            }
         });
     return StoreListView;
 });

--- a/templates/handlebars/thirdchannel/activities/sales_marquee.hbs
+++ b/templates/handlebars/thirdchannel/activities/sales_marquee.hbs
@@ -1,0 +1,9 @@
+<button class="marquee-nav previous {{#unless canNavBack}}hidden{{/unless}}">
+  <i class="ic ic_left"></i>
+</button>
+
+<div class="sales-figure"></div>
+
+<button class="marquee-nav next {{#unless canNavForward}}hidden{{/unless}}">
+  <i class="ic ic_right"></i>
+</button>

--- a/templates/handlebars/thirdchannel/activities/sales_widget.hbs
+++ b/templates/handlebars/thirdchannel/activities/sales_widget.hbs
@@ -1,16 +1,16 @@
 <section class="sales-widget pure-g">
   <div class="text col-2-3" style="display: inline;">
-  {{#if message}}
+  {{#if showMessage}}
   <span><i class="sales-message">
     {{message}}
     </i>
    </span>
   {{else}}
-    QTD $ Sales:
+    {{widget.label}}:
     <span class="sales-button">
-        <a href={{salesUrl}} class="percentage-change activity-feed-qtd {{ percentageChangeClass salesChange }}">
-            <i class="fa {{percentageChangeIcon salesChange }} change-icon"></i>
-            {{formatPercentageChange salesChange}}
+        <a href={{salesUrl}} class="percentage-change activity-feed-qtd {{ percentageChangeClass widget.change }}">
+            <i class="fa {{percentageChangeIcon widget.change }} change-icon"></i>
+            {{formatPercentageChange widget.change}}
         </a>
     </span>
     {{#if mostRecent}}

--- a/templates/handlebars/thirdchannel/activities/sales_widget.hbs
+++ b/templates/handlebars/thirdchannel/activities/sales_widget.hbs
@@ -7,8 +7,8 @@
   {{else}}
     {{widget.label}}:
     <span class="sales-button">
-        <a href={{salesUrl}} class="percentage-change activity-feed-qtd {{ percentageChangeClass widget.change }}">
-            <i class="fa {{percentageChangeIcon widget.change }} change-icon"></i>
+        <a {{#if salesUrl}}href={{salesUrl}}{{/if}} class="percentage-change activity-feed-qtd {{percentageChangeClass widget.change}}">
+            <i class="fa {{percentageChangeIcon widget.change}} change-icon"></i>
             {{formatPercentageChange widget.change}}
         </a>
     </span>

--- a/templates/handlebars/thirdchannel/activities/sales_widget.hbs
+++ b/templates/handlebars/thirdchannel/activities/sales_widget.hbs
@@ -1,5 +1,5 @@
 <section class="sales-widget pure-g">
-  <div class="text col-2-3" style="display: inline;">
+  <div class="text col-2-3">
   {{#if showMessage}}
   <span>
     <i class="sales-message">{{message}}</i>

--- a/templates/handlebars/thirdchannel/activities/sales_widget.hbs
+++ b/templates/handlebars/thirdchannel/activities/sales_widget.hbs
@@ -1,9 +1,8 @@
 <section class="sales-widget pure-g">
   <div class="text col-2-3" style="display: inline;">
   {{#if showMessage}}
-  <span><i class="sales-message">
-    {{message}}
-    </i>
+  <span>
+    <i class="sales-message">{{message}}</i>
    </span>
   {{else}}
     {{widget.label}}:

--- a/templates/handlebars/thirdchannel/activity.hbs
+++ b/templates/handlebars/thirdchannel/activity.hbs
@@ -21,6 +21,7 @@
                     <a href="/programs/{{current_program}}/profiles/{{user_id}}">{{user_name}}</a>
                 </p>
             </div>
+            <div class="sales-marquee"></div>
         </div>
 
         <div class="activity-details"></div>

--- a/templates/handlebars/thirdchannel/activity.hbs
+++ b/templates/handlebars/thirdchannel/activity.hbs
@@ -1,27 +1,29 @@
 <div class="activity-holder">
     <div class="activity">
-        <div class="activity-meta">
-            {{> user_image user_image}}
+        <div class="activity-header">
+          <div class="activity-meta">
+              {{> user_image user_image}}
 
-            <div class="bar-body">
-                {{#if_eq type "Checkin"}}
-                <p>
-                    <a href="{{location.profile_url}}">{{location.store}}</a>
-                    , {{location.address}}
-                </p>
-                {{/if_eq}}
-                {{#if_eq checkin_type "special_project"}}
-                <p class="activity-special-project">
-                    {{survey_title}}
-                </p>
-                {{/if_eq}}
-                <p>
-                    <span><i class="timestamp" data-livestamp="{{created_at}}"></i></span> <span>({{formatSecondsToDateTime created_at}})</span>
-                    by
-                    <a href="/programs/{{current_program}}/profiles/{{user_id}}">{{user_name}}</a>
-                </p>
-            </div>
-            <div class="sales-marquee"></div>
+              <div class="bar-body">
+                  {{#if_eq type "Checkin"}}
+                  <p>
+                      <a href="{{location.profile_url}}">{{location.store}}</a>
+                      , {{location.address}}
+                  </p>
+                  {{/if_eq}}
+                  {{#if_eq checkin_type "special_project"}}
+                  <p class="activity-special-project">
+                      {{survey_title}}
+                  </p>
+                  {{/if_eq}}
+                  <p>
+                      <span><i class="timestamp" data-livestamp="{{created_at}}"></i></span> <span>({{formatSecondsToDateTime created_at}})</span>
+                      by
+                      <a href="/programs/{{current_program}}/profiles/{{user_id}}">{{user_name}}</a>
+                  </p>
+              </div>
+          </div>
+          <div class="sales-marquee"></div>
         </div>
 
         <div class="activity-details"></div>

--- a/templates/handlebars/thirdchannel/stores/rows.hbs
+++ b/templates/handlebars/thirdchannel/stores/rows.hbs
@@ -1,26 +1,13 @@
 {{#rows}}
 <div class="item pure-g">
-    <div class="col-md-1 col-2-5">
+    <div class="col-md-1 col-1-3">
         <a href="{{links.profile}}">{{name}}</a>
     </div>
-    <div class="col-md-1 col-2-5">
+    <div class="col-md-1 col-1-3">
         {{address}}
     </div>
     <div class="col-md-1 col-1-5">
-    {{#if sales_data}}
-        {{#if sales_data.message}}
-            <span>
-            <i class="medium-blue">{{sales_data.message}}</i>
-        </span>
-        {{else}}
-            <span class="sales-button">
-            <a href="{{links.profile}}/sales" class="percentage-change activity-feed-qtd {{ percentageChangeClass sales_data.sales_change }}">
-                <i class="fa {{percentageChangeIcon sales_data.sales_change }} change-icon"></i>
-                <div class="pull-right">{{formatPercentageChange sales_data.sales_change}}</div>
-            </a>
-        </span>
-        {{/if}}
-    {{/if}}
+      <div id="{{id}}" class="sales-marquee"></div>
     </div>
 </div>
 {{else}}


### PR DESCRIPTION
**What:** Introduces a new component, `SalesMarquee`, that will display $ Sales, Units OH, and Units Sold data on the activity feed as part of the activity. Some refactoring of the activity-meta area to allow for some visual changes.

**Jira:** https://thirdchannel.atlassian.net/browse/SD-287

<img width="1210" alt="screen shot 2017-02-08 at 10 51 15 am" src="https://cloud.githubusercontent.com/assets/579649/22746261/2cbd68cc-edf1-11e6-8ede-64164f4c3467.png">
<img width="535" alt="screen shot 2017-02-08 at 10 51 33 am" src="https://cloud.githubusercontent.com/assets/579649/22746260/2cb84130-edf1-11e6-94a6-dc3b39019a28.png">
