### PR TITLE
TC-5074 - unable to start an optional activity packet task

### DIFF
--- a/js/apps/thirdchannel/views/checkins/task_list.js
+++ b/js/apps/thirdchannel/views/checkins/task_list.js
@@ -19,6 +19,7 @@ define(function(require){
             this.$('.chosen-search input[type=text]').attr('placeholder', 'Search for task');
             this.valid = false;
             this.$formError = this.$('form .error');
+            this.$groupedTaskForm = this.$('form.task.grouped');
             return this;
         },
         submit: function(e) {
@@ -40,15 +41,18 @@ define(function(require){
                 surveyId = selectedOption.data('survey'),
                 packetId = selectedOption.data('packet'),
                 taskId = selectedOption.data('task'),
-                categoryId = selectedOption.data('category');
+                categoryId = selectedOption.data('category'),
+                path = selectedOption.data('path');
 
             this.valid = (surveyId || packetId) && taskId;
 
             if (this.valid) {
-                this.$('form.task.grouped input[name=survey_uuid]').val(surveyId);
-                this.$('form.task.grouped input[name=task_uuid]').val(taskId);
-                this.$('form.task.grouped input[name=category_id]').val(categoryId);
-                this.$('form.task.grouped input[name=packet_uuid]').val(packetId);
+                this.$groupedTaskForm.attr('action', path);
+                this.$groupedTaskForm.find('input[name=survey_uuid]').val(surveyId);
+                this.$groupedTaskForm.find('input[name=task_uuid]').val(taskId);
+                this.$groupedTaskForm.find('input[name=category_id]').val(categoryId);
+                this.$groupedTaskForm.find('input[name=packet_uuid]').val(packetId);
+
                 this.hideError();
             } else {
                 if(selectedOption.value !== undefined) {

--- a/js/apps/thirdchannel/views/checkins/task_list.js
+++ b/js/apps/thirdchannel/views/checkins/task_list.js
@@ -38,15 +38,17 @@ define(function(require){
         updateInputs: function () {
             var selectedOption = this.$('select :selected'),
                 surveyId = selectedOption.data('survey'),
+                packetId = selectedOption.data('packet'),
                 taskId = selectedOption.data('task'),
                 categoryId = selectedOption.data('category');
 
-            this.valid = surveyId && taskId;
+            this.valid = (surveyId || packetId) && taskId;
 
             if (this.valid) {
                 this.$('form.task.grouped input[name=survey_uuid]').val(surveyId);
                 this.$('form.task.grouped input[name=task_uuid]').val(taskId);
                 this.$('form.task.grouped input[name=category_id]').val(categoryId);
+                this.$('form.task.grouped input[name=packet_uuid]').val(packetId);
                 this.hideError();
             } else {
                 if(selectedOption.value !== undefined) {

--- a/templates/handlebars/thirdchannel/checkins/tasks.hbs
+++ b/templates/handlebars/thirdchannel/checkins/tasks.hbs
@@ -64,6 +64,7 @@
         <input name="survey_uuid" type="hidden">
         <input name="task_uuid" type="hidden">
         <input name="category_id" type="hidden">
+        <input name="packet_uuid" type="hidden">
         <input name="authenticity_token" value="{{auth_token}}" type="hidden">
         <div class="col-1-1">
             <label>Optional Activities:</label>
@@ -77,7 +78,7 @@
                 {{#each job.grouped_tasks}}
                     <optgroup label="{{name}}">
                         {{#each tasks}}
-                            <option data-survey="{{surveyUUID}}" data-task="{{uuid}}" data-category="{{category_id}}">
+                            <option data-survey="{{surveyUUID}}" data-packet="{{packet_uuid}}" data-task="{{uuid}}" data-category="{{category_id}}">
                                 {{name}}{{#if category_name}} - {{category_name}}{{/if}}{{#required}}<span class="subtle-instruction">*</span>{{/required}}
                             </option>
                         {{/each}}

--- a/templates/handlebars/thirdchannel/checkins/tasks.hbs
+++ b/templates/handlebars/thirdchannel/checkins/tasks.hbs
@@ -78,7 +78,7 @@
                 {{#each job.grouped_tasks}}
                     <optgroup label="{{name}}">
                         {{#each tasks}}
-                            <option data-survey="{{surveyUUID}}" data-packet="{{packet_uuid}}" data-task="{{uuid}}" data-category="{{category_id}}">
+                            <option data-survey="{{surveyUUID}}" data-packet="{{packet_uuid}}" data-task="{{uuid}}" data-category="{{category_id}}" data-path="{{form_url}}"">
                                 {{name}}{{#if category_name}} - {{category_name}}{{/if}}{{#required}}<span class="subtle-instruction">*</span>{{/required}}
                             </option>
                         {{/each}}


### PR DESCRIPTION
https://thirdchannel.atlassian.net/browse/TC-5074

The category select only dealt with normal tasks, needed to add support for activity packet based tasks.

Form required `packet_uuid` input and the action path is different.