### PR TITLE
TC-5305 - if no data is returned set the results as an empty array

### DIFF
--- a/js/apps/thirdchannel/views/manage/jobs/create.js
+++ b/js/apps/thirdchannel/views/manage/jobs/create.js
@@ -96,6 +96,10 @@ define(function(require) {
                         };
                     },
                     processResults: function (data) {
+                        if(!data) {
+                            return { results: [] };
+                        }
+
                         return {
                             results: data.map(function (item) {
                                 item.text = item.name + ' <' + item.email + '> - ' + item.address;


### PR DESCRIPTION
https://thirdchannel.atlassian.net/browse/TC-5305

Since the query now returns nil instead of empty array when no results are found, set the auto-complete results to an empty array.