### PR TITLE
[FAS-107]: Scroll to page sections with JS rather than traditional page anchors

### DIFF
--- a/js/apps/thirdchannel/views/reports/field_activity/overview.js
+++ b/js/apps/thirdchannel/views/reports/field_activity/overview.js
@@ -12,6 +12,10 @@ define(function(require) {
       el: ".field-activities-overview",
       template: HandlebarsTemplates['thirdchannel/reports/field_activity/overview'],
 
+      events: {
+        'click .anchor': 'scrollToSection'
+      },
+
       initialize: function(options) {
         this.loadingView = new LoadingView();
         this.$el.html(this.loadingView.render().$el);
@@ -42,6 +46,20 @@ define(function(require) {
         this.model.updateFilters(params);
         this.$el.html(this.loadingView.render().$el);
         this.fetchReport();
+      },
+
+      scrollToSection: function(event) {
+        event.preventDefault();
+        /*
+          Normally we can use traditional page anchors to scrool to sections, but with the filter params,
+          this practice doesn't work, and we instead get some filtering bugs.
+        */
+
+        var section = $(event.target).data('section');
+
+        $('.content-holder').animate({
+          scrollTop: $(section).offset().top
+        }, 500);
       }
     });
 });

--- a/templates/handlebars/thirdchannel/reports/field_activity/overview.hbs
+++ b/templates/handlebars/thirdchannel/reports/field_activity/overview.hbs
@@ -3,9 +3,9 @@
   <div class="header-index">
     <h2>{{fieldActivities.label}}</h2>
     <div>
-      <a href="#associate_education">Associate Education</a> |
-      <a href="#consumer_engagement_selling">Consumer Engagement & Selling</a> |
-      <a href="#merchandising">Merchandising</a> |
+      <a class="anchor" data-section="#associate_education" href="#associate_education">Associate Education</a> |
+      <a class="anchor" data-section="#consumer_engagement_selling" href="#consumer_engagement_selling">Consumer Engagement & Selling</a> |
+      <a class="anchor" data-section="#merchandising" href="#merchandising">Merchandising</a> |
       <a href="/programs/{{programId}}/reports">All Activity Reports</a>
     </div>
   </div>


### PR DESCRIPTION
**What:** Update field activities to scroll to sections via JS rather than using IDs in anchor tags.

**Why:** When filters are applied to this page, attempting to scroll via the anchor ends up causing the filters to trigger an update and duplicate data rather than scrolling to the page. This method allows us to avoid that situation.

**Jira:** https://thirdchannel.atlassian.net/browse/FAS-107