### PR TITLE
[FAS-113] DateSlider component should properly update Filters component

### DIFF
--- a/js/apps/thirdchannel/views/filter/dateSlider.js
+++ b/js/apps/thirdchannel/views/filter/dateSlider.js
@@ -45,6 +45,10 @@ define(function(require) {
             this.startPoint = options.startPoint;
           }
 
+          if (options.pageFilters) {
+            this.filters = options.pageFilters;
+          }
+
           this.dateMap = options.dateMap || this.defaultDateMap;
 
           this.render();
@@ -96,10 +100,18 @@ define(function(require) {
         },
 
         triggerFilterSet: function(value) {
-          context.trigger('filter:set', [
+          var filterUpdates = [
             {name: "start_date", value: this.dateMap[value].start_date},
             {name: "end_date", value: this.endDate}
-          ]);
+          ];
+
+          filterUpdates.forEach(function(filter) {
+            var filterMatch = _.findWhere(this.filters.components, {filterParam: filter.name});
+            filterMatch.clear();
+            filterMatch.addFilterByValue(filter.value);
+          }.bind(this));
+
+          context.trigger('filter:set', filterUpdates);
         },
 
         focusDateFilters: function() {

--- a/js/apps/thirdchannel/views/reports/field_activity/index/main.js
+++ b/js/apps/thirdchannel/views/reports/field_activity/index/main.js
@@ -1,13 +1,15 @@
 define(function(require) {
     var $ = require('jquery'),
         _ = require('underscore'),
+        DateSliderView = require('thirdchannel/views/filter/dateSlider'),
         FieldActivitiesReportView = require('thirdchannel/views/reports/field_activity/report'),
         Filter = require('thirdchannel/views/filter/main');
 
     return {
         init: function (options) {
-            Filter.init();
+            this.filters = Filter.init();
             new FieldActivitiesReportView(options).render();
+            new DateSliderView({el: '.date-slider-container', startPoint: 3, pageFilters: this.filters});
         }
     };
 });

--- a/js/apps/thirdchannel/views/reports/field_activity/report.js
+++ b/js/apps/thirdchannel/views/reports/field_activity/report.js
@@ -3,7 +3,6 @@ define(function(require) {
         _ = require('underscore'),
         context = require('context'),
         HandlebarsTemplates = require('handlebarsTemplates'),
-        DateSliderView = require('thirdchannel/views/filter/dateSlider'),
         OverviewView = require('thirdchannel/views/reports/field_activity/overview'),
         ReportSection = require('thirdchannel/views/reports/field_activity/report_section');
 
@@ -14,8 +13,6 @@ define(function(require) {
 
         initialize: function(options) {
           this.$el.html(this.template({sections: this.sections}));
-
-          new DateSliderView({el: '.date-slider-container', startPoint: 3});
 
           this.listenTo(context, 'filter:query', this.handleFilter);
 


### PR DESCRIPTION
**What:** DateSlider now will update the start_date and end_date components in the page filters whenever a selection is updated.

**Why:** DateSlider is sort of a convenience interface for the date selection portion of the filters. It's not necessarily a 1:1 feature, which is was DateSlider doesn't extend from Filter, but it's actions affect what the Filters menu should do.

**Jira:** https://thirdchannel.atlassian.net/browse/FAS-113