### PR TITLE
[FAS-105] On initial load, match slider state to current filter state

### DIFF
--- a/js/apps/thirdchannel/views/filter/dateSlider.js
+++ b/js/apps/thirdchannel/views/filter/dateSlider.js
@@ -117,22 +117,22 @@ define(function(require) {
         },
 
         setStartPointFromFilters: function() {
+          var startPoint = Object.keys(this.dateMap).length - 1; // Set a default startPoint to last item in dateMap
           var startDateFilter = _.find(this.filters.components, function(filter) {
             return filter.filterParam === "start_date";
-          }).activeFilters[0].options.value;
+          }).activeFilters[0].getQueryValue(); // start_date should only ever have a max of one active item
           var endDateFilter = _.find(this.filters.components, function(filter) {
             return filter.filterParam === "end_date";
-          }).activeFilters[0].options.value;
+          }).activeFilters[0].getQueryValue(); // end_date should only ever have a max of one active item
           var endDateMatch = endDateFilter === this.endDate;
 
           for (var property in this.dateMap) {
             if (endDateMatch && (this.dateMap[property].start_date) === startDateFilter) {
-              return property;
+              startPoint = property; // If we get a range match, update startPoint
             }
           }
 
-          // If no matches in the map, return the last filter index (Custom)
-          return Object.keys(this.dateMap).length - 1;
+          return startPoint;
         },
 
         focusDateFilters: function() {

--- a/js/apps/thirdchannel/views/filter/dateSlider.js
+++ b/js/apps/thirdchannel/views/filter/dateSlider.js
@@ -41,15 +41,17 @@ define(function(require) {
         },
 
         initialize: function(options) {
-          if (options.startPoint) {
-            this.startPoint = options.startPoint;
-          }
+          this.dateMap = options.dateMap || this.defaultDateMap;
 
           if (options.pageFilters) {
             this.filters = options.pageFilters;
           }
 
-          this.dateMap = options.dateMap || this.defaultDateMap;
+          if (options.startPoint) {
+            this.startPoint = options.startPoint;
+          } else {
+            this.startPoint = this.setStartPointFromFilters();
+          }
 
           this.render();
         },
@@ -112,6 +114,25 @@ define(function(require) {
           }.bind(this));
 
           context.trigger('filter:set', filterUpdates);
+        },
+
+        setStartPointFromFilters: function() {
+          var startDateFilter = _.find(this.filters.components, function(filter) {
+            return filter.filterParam === "start_date";
+          }).activeFilters[0].options.value;
+          var endDateFilter = _.find(this.filters.components, function(filter) {
+            return filter.filterParam === "end_date";
+          }).activeFilters[0].options.value;
+          var endDateMatch = endDateFilter === this.endDate;
+
+          for (var property in this.dateMap) {
+            if (endDateMatch && (this.dateMap[property].start_date) === startDateFilter) {
+              return property;
+            }
+          }
+
+          // If no matches in the map, return the last filter index (Custom)
+          return Object.keys(this.dateMap).length - 1;
         },
 
         focusDateFilters: function() {

--- a/js/apps/thirdchannel/views/reports/field_activity/index/main.js
+++ b/js/apps/thirdchannel/views/reports/field_activity/index/main.js
@@ -9,7 +9,7 @@ define(function(require) {
         init: function (options) {
             this.filters = Filter.init();
             new FieldActivitiesReportView(options).render();
-            new DateSliderView({el: '.date-slider-container', startPoint: 3, pageFilters: this.filters});
+            new DateSliderView({el: '.date-slider-container', pageFilters: this.filters});
         }
     };
 });


### PR DESCRIPTION
**What:** When the date slider initializes, check the page's current filters, and compare to the slider's current date mapping. If there's a match in ranges, set the slider position to that range, otherwise, default to the "Custom" option.

**Why:** When navigating back and forth between this page, the slider would also reset to 1 month, even if the filters were different in the URL. This also allows us to better deeplink this page so we can send URLs with particular dates filtered by default.

**Jira:** https://thirdchannel.atlassian.net/browse/FAS-105