### PR TITLE
[TC-5390 ] Require email opportunity preference selection when editing agent profile

### DIFF
--- a/js/apps/erudition/views/profile/edit.js
+++ b/js/apps/erudition/views/profile/edit.js
@@ -53,8 +53,6 @@ define(function (require) {
 
             this.$el.append(this.template(model));
 
-            this.$('select').chosen({disable_search: true, width: "100%"});
-
             if(context.content.requireValidation) {
                 this.beginValidation();
             }

--- a/templates/handlebars/erudition/shared/_notifications.hbs
+++ b/templates/handlebars/erudition/shared/_notifications.hbs
@@ -5,8 +5,8 @@
 
         <label for="emailOpportunities">Would you like to receive emails about future opportunities?</label>
 
-        <select name="emailOpportunities" id="emailOpportunities" data-placeholder="Select Preference" data-rule-required="true">
-            <option></option>
+        <select name="emailOpportunities" id="emailOpportunities" data-rule-required="true">
+            <option value="">Select Preference</option>
             {{#select person.emailOpportunities}}
                 <option value="Yes">Yes</option>
                 <option value="No">No</option>


### PR DESCRIPTION
**What:** Removed the addition of the `chosen` variation of the email preferences dropdown when a user is editing their profile.

**Why:** It seems as though `jquery-validation` and `chosen` don't play nicely together. Since the rest of the inputs on this page aren't of the `chosen` variety, I took it out.

This now requires that a user sets their email preferences when editing their profile.

**Jira:** https://thirdchannel.atlassian.net/browse/TC-5390